### PR TITLE
S1.1: BitVecState bitwise ops

### DIFF
--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -940,6 +940,168 @@ test "BitVecState: bitXor width=1 truth table" {
     try std.testing.expect(un.bitXor(un).equals(un));
 }
 
+test "BitVecState: bitAnd at widths > 1" {
+    // Width 4, all-defined: per-bit AND of arbitrary patterns.
+    {
+        const a = BitVecState{ .value = 0b1100, .defined = 0b1111, .width = 4 };
+        const b = BitVecState{ .value = 0b1010, .defined = 0b1111, .width = 4 };
+        const result = a.bitAnd(b);
+        try std.testing.expectEqual(@as(u64, 0b1000), result.value);
+        try std.testing.expectEqual(@as(u64, 0b1111), result.defined);
+        try std.testing.expectEqual(@as(u8, 4), result.width);
+    }
+
+    // Width 4, mixed undefined: a defined-low input forces the result bit
+    // to low even when the other input is undefined at that bit.
+    //   a (bit 0..3): hi, undef, lo, hi  -> value=0b1001, defined=0b1101
+    //   b (bit 0..3): lo, hi,    hi, hi  -> value=0b1110, defined=0b1111
+    //   result:       lo, undef, lo, hi  -> value=0b1000, defined=0b1101
+    {
+        const a = BitVecState{ .value = 0b1001, .defined = 0b1101, .width = 4 };
+        const b = BitVecState{ .value = 0b1110, .defined = 0b1111, .width = 4 };
+        const result = a.bitAnd(b);
+        try std.testing.expectEqual(@as(u64, 0b1000), result.value);
+        try std.testing.expectEqual(@as(u64, 0b1101), result.defined);
+    }
+
+    // Width 8, all-defined.
+    {
+        const a = BitVecState{ .value = 0xF0, .defined = 0xFF, .width = 8 };
+        const b = BitVecState{ .value = 0xAA, .defined = 0xFF, .width = 8 };
+        const result = a.bitAnd(b);
+        try std.testing.expectEqual(@as(u64, 0xA0), result.value);
+        try std.testing.expectEqual(@as(u64, 0xFF), result.defined);
+    }
+
+    // Width 64, all-defined: full-register pattern.
+    {
+        const a = BitVecState{ .value = 0xF0F0F0F0F0F0F0F0, .defined = std.math.maxInt(u64), .width = 64 };
+        const b = BitVecState{ .value = 0xAAAAAAAAAAAAAAAA, .defined = std.math.maxInt(u64), .width = 64 };
+        const result = a.bitAnd(b);
+        try std.testing.expectEqual(@as(u64, 0xA0A0A0A0A0A0A0A0), result.value);
+        try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), result.defined);
+    }
+
+    // All-undefined remains all-undefined at any width.
+    try std.testing.expect(BitVecState.undefined_(4).bitAnd(BitVecState.undefined_(4)).equals(BitVecState.undefined_(4)));
+    try std.testing.expect(BitVecState.undefined_(64).bitAnd(BitVecState.undefined_(64)).equals(BitVecState.undefined_(64)));
+}
+
+test "BitVecState: bitOr at widths > 1" {
+    // Width 4, all-defined: per-bit OR of arbitrary patterns.
+    {
+        const a = BitVecState{ .value = 0b1100, .defined = 0b1111, .width = 4 };
+        const b = BitVecState{ .value = 0b1010, .defined = 0b1111, .width = 4 };
+        const result = a.bitOr(b);
+        try std.testing.expectEqual(@as(u64, 0b1110), result.value);
+        try std.testing.expectEqual(@as(u64, 0b1111), result.defined);
+    }
+
+    // Width 4, mixed undefined: a defined-high input forces the result bit
+    // to high even when the other input is undefined at that bit.
+    //   a (bit 0..3): hi, undef, lo, hi  -> value=0b1001, defined=0b1101
+    //   b (bit 0..3): lo, hi,    hi, lo  -> value=0b0110, defined=0b1111
+    //   result:       hi, hi,    hi, hi  -> value=0b1111, defined=0b1111
+    {
+        const a = BitVecState{ .value = 0b1001, .defined = 0b1101, .width = 4 };
+        const b = BitVecState{ .value = 0b0110, .defined = 0b1111, .width = 4 };
+        const result = a.bitOr(b);
+        try std.testing.expectEqual(@as(u64, 0b1111), result.value);
+        try std.testing.expectEqual(@as(u64, 0b1111), result.defined);
+    }
+
+    // Width 8, all-defined: complementary halves OR to all-ones.
+    {
+        const a = BitVecState{ .value = 0xF0, .defined = 0xFF, .width = 8 };
+        const b = BitVecState{ .value = 0x0F, .defined = 0xFF, .width = 8 };
+        const result = a.bitOr(b);
+        try std.testing.expectEqual(@as(u64, 0xFF), result.value);
+        try std.testing.expectEqual(@as(u64, 0xFF), result.defined);
+    }
+
+    // Width 64, all-defined.
+    {
+        const a = BitVecState{ .value = 0xF0F0F0F0F0F0F0F0, .defined = std.math.maxInt(u64), .width = 64 };
+        const b = BitVecState{ .value = 0x0F0F0F0F0F0F0F0F, .defined = std.math.maxInt(u64), .width = 64 };
+        const result = a.bitOr(b);
+        try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), result.value);
+        try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), result.defined);
+    }
+
+    // All-undefined remains all-undefined.
+    try std.testing.expect(BitVecState.undefined_(4).bitOr(BitVecState.undefined_(4)).equals(BitVecState.undefined_(4)));
+    try std.testing.expect(BitVecState.undefined_(64).bitOr(BitVecState.undefined_(64)).equals(BitVecState.undefined_(64)));
+}
+
+test "BitVecState: bitXor at widths > 1" {
+    // Width 4, all-defined: per-bit XOR of arbitrary patterns.
+    {
+        const a = BitVecState{ .value = 0b1100, .defined = 0b1111, .width = 4 };
+        const b = BitVecState{ .value = 0b1010, .defined = 0b1111, .width = 4 };
+        const result = a.bitXor(b);
+        try std.testing.expectEqual(@as(u64, 0b0110), result.value);
+        try std.testing.expectEqual(@as(u64, 0b1111), result.defined);
+    }
+
+    // Width 4, mixed undefined: any undefined input bit makes the result
+    // bit undefined, regardless of the other operand. The XOR's "defined
+    // iff both defined" rule shows up here as defined = a.defined & b.defined.
+    //   a (bit 0..3): hi, undef, lo, hi  -> value=0b1001, defined=0b1101
+    //   b (bit 0..3): lo, hi,    hi, lo  -> value=0b0110, defined=0b1111
+    //   defined = 0b1101 & 0b1111 = 0b1101
+    //   value   = (0b1001 ^ 0b0110) & 0b1101 = 0b1111 & 0b1101 = 0b1101
+    {
+        const a = BitVecState{ .value = 0b1001, .defined = 0b1101, .width = 4 };
+        const b = BitVecState{ .value = 0b0110, .defined = 0b1111, .width = 4 };
+        const result = a.bitXor(b);
+        try std.testing.expectEqual(@as(u64, 0b1101), result.value);
+        try std.testing.expectEqual(@as(u64, 0b1101), result.defined);
+    }
+
+    // Width 8, all-defined: all-ones XOR with low nibble flips the low half.
+    {
+        const a = BitVecState{ .value = 0xFF, .defined = 0xFF, .width = 8 };
+        const b = BitVecState{ .value = 0x0F, .defined = 0xFF, .width = 8 };
+        const result = a.bitXor(b);
+        try std.testing.expectEqual(@as(u64, 0xF0), result.value);
+        try std.testing.expectEqual(@as(u64, 0xFF), result.defined);
+    }
+
+    // Width 64, all-defined.
+    {
+        const a = BitVecState{ .value = std.math.maxInt(u64), .defined = std.math.maxInt(u64), .width = 64 };
+        const b = BitVecState{ .value = 0x0F0F0F0F0F0F0F0F, .defined = std.math.maxInt(u64), .width = 64 };
+        const result = a.bitXor(b);
+        try std.testing.expectEqual(@as(u64, 0xF0F0F0F0F0F0F0F0), result.value);
+        try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), result.defined);
+    }
+
+    // Any undefined input propagates as undefined.
+    {
+        const lo4 = BitVecState.low(4);
+        const un4 = BitVecState.undefined_(4);
+        try std.testing.expect(lo4.bitXor(un4).equals(un4));
+        try std.testing.expect(un4.bitXor(lo4).equals(un4));
+        try std.testing.expect(un4.bitXor(un4).equals(un4));
+    }
+}
+
+test "BitVecState: bitwise ops mask out-of-width payload to zero" {
+    // The public constructors normally prevent out-of-width payload, but
+    // the bitwise ops still apply `widthMask` to result bitmaps so a
+    // hand-built value with dirty high bits cannot leak past `width`.
+    const dirty_a = BitVecState{ .value = 0xFF, .defined = 0xFF, .width = 4 };
+    const dirty_b = BitVecState{ .value = 0xFF, .defined = 0xFF, .width = 4 };
+    const high_bits = ~widthMask(4);
+
+    try std.testing.expectEqual(@as(u64, 0), dirty_a.bitAnd(dirty_b).value & high_bits);
+    try std.testing.expectEqual(@as(u64, 0), dirty_a.bitAnd(dirty_b).defined & high_bits);
+    try std.testing.expectEqual(@as(u64, 0), dirty_a.bitOr(dirty_b).value & high_bits);
+    try std.testing.expectEqual(@as(u64, 0), dirty_a.bitOr(dirty_b).defined & high_bits);
+    try std.testing.expectEqual(@as(u64, 0), dirty_a.bitXor(dirty_b).value & high_bits);
+    try std.testing.expectEqual(@as(u64, 0), dirty_a.bitXor(dirty_b).defined & high_bits);
+}
+
 test "BitVecState: transport byte matches enum declaration order" {
     // The WASM API contract uses @intFromEnum(State), which is the State
     // enum's declaration order: undefined=0, low=1, high=2. The new

--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -169,6 +169,52 @@ pub const BitVecState = struct {
         };
     }
 
+    /// Bitwise AND with three-state semantics: a bit is low if either
+    /// operand's bit is defined-low, high if both are defined-high, and
+    /// undefined otherwise. Reduces to the existing width=1 AND predicate
+    /// in `recalculateAndReschedule` for all nine three-state combinations.
+    pub fn bitAnd(self: BitVecState, other: BitVecState) BitVecState {
+        std.debug.assert(self.width == other.width);
+        const m = widthMask(self.width);
+        const high_mask = self.value & self.defined & other.value & other.defined;
+        const low_mask = ((~self.value) & self.defined) | ((~other.value) & other.defined);
+        return .{
+            .value = high_mask & m,
+            .defined = (high_mask | low_mask) & m,
+            .width = self.width,
+        };
+    }
+
+    /// Bitwise OR with three-state semantics: a bit is high if either
+    /// operand's bit is defined-high, low if both are defined-low, and
+    /// undefined otherwise. Dual of `bitAnd`.
+    pub fn bitOr(self: BitVecState, other: BitVecState) BitVecState {
+        std.debug.assert(self.width == other.width);
+        const m = widthMask(self.width);
+        const high_mask = (self.value & self.defined) | (other.value & other.defined);
+        const low_mask = ((~self.value) & self.defined) & ((~other.value) & other.defined);
+        return .{
+            .value = high_mask & m,
+            .defined = (high_mask | low_mask) & m,
+            .width = self.width,
+        };
+    }
+
+    /// Bitwise XOR with three-state semantics: a bit is defined iff both
+    /// operands' bits are defined; its value is `self.value ^ other.value`
+    /// within the both-defined mask. Any undefined input bit propagates as
+    /// undefined regardless of the other operand.
+    pub fn bitXor(self: BitVecState, other: BitVecState) BitVecState {
+        std.debug.assert(self.width == other.width);
+        const m = widthMask(self.width);
+        const both_defined = self.defined & other.defined;
+        return .{
+            .value = (self.value ^ other.value) & both_defined & m,
+            .defined = both_defined & m,
+            .width = self.width,
+        };
+    }
+
     /// Width=1 helper: defined and value bit set.
     pub fn isHigh(self: BitVecState) bool {
         std.debug.assert(self.width == 1);
@@ -840,6 +886,58 @@ test "BitVecState: flip preserves undefined, swaps defined" {
     try std.testing.expect(BitVecState.undefined_(1).flip().equals(BitVecState.undefined_(1)));
     try std.testing.expect(BitVecState.low(1).flip().equals(BitVecState.high(1)));
     try std.testing.expect(BitVecState.high(1).flip().equals(BitVecState.low(1)));
+}
+
+test "BitVecState: bitAnd width=1 matches the engine's AND predicate" {
+    // Mirror the three-branch logic in `recalculateAndReschedule`'s
+    // and_gate arm so the new bitwise op is provably equivalent at the
+    // width the existing engine actually exercises.
+    const refAnd = struct {
+        fn pred(a: BitVecState, b: BitVecState) BitVecState {
+            if (a.isLow() or b.isLow()) return BitVecState.low(1);
+            if (a.isUndefined() or b.isUndefined()) return BitVecState.undefined_(1);
+            return BitVecState.high(1);
+        }
+    };
+
+    const states = [_]BitVecState{ BitVecState.low(1), BitVecState.high(1), BitVecState.undefined_(1) };
+    for (states) |a| {
+        for (states) |b| {
+            try std.testing.expect(a.bitAnd(b).equals(refAnd.pred(a, b)));
+        }
+    }
+}
+
+test "BitVecState: bitOr width=1 truth table" {
+    const lo = BitVecState.low(1);
+    const hi = BitVecState.high(1);
+    const un = BitVecState.undefined_(1);
+
+    try std.testing.expect(lo.bitOr(lo).equals(lo));
+    try std.testing.expect(lo.bitOr(hi).equals(hi));
+    try std.testing.expect(lo.bitOr(un).equals(un));
+    try std.testing.expect(hi.bitOr(lo).equals(hi));
+    try std.testing.expect(hi.bitOr(hi).equals(hi));
+    try std.testing.expect(hi.bitOr(un).equals(hi));
+    try std.testing.expect(un.bitOr(lo).equals(un));
+    try std.testing.expect(un.bitOr(hi).equals(hi));
+    try std.testing.expect(un.bitOr(un).equals(un));
+}
+
+test "BitVecState: bitXor width=1 truth table" {
+    const lo = BitVecState.low(1);
+    const hi = BitVecState.high(1);
+    const un = BitVecState.undefined_(1);
+
+    try std.testing.expect(lo.bitXor(lo).equals(lo));
+    try std.testing.expect(lo.bitXor(hi).equals(hi));
+    try std.testing.expect(lo.bitXor(un).equals(un));
+    try std.testing.expect(hi.bitXor(lo).equals(hi));
+    try std.testing.expect(hi.bitXor(hi).equals(lo));
+    try std.testing.expect(hi.bitXor(un).equals(un));
+    try std.testing.expect(un.bitXor(lo).equals(un));
+    try std.testing.expect(un.bitXor(hi).equals(un));
+    try std.testing.expect(un.bitXor(un).equals(un));
 }
 
 test "BitVecState: transport byte matches enum declaration order" {


### PR DESCRIPTION
## Summary

- Adds `bitAnd`, `bitOr`, `bitXor` as width-agnostic three-state ops on `BitVecState`. Pure additions in `lib/circuit.zig`; no callers yet.
- Width=1 tests assert behavioral equivalence with the existing AND predicate in `recalculateAndReschedule` across all nine three-state combinations, so the gate evaluator rewrite in S1.4 can land later without changing any width=1 semantics.
- Width 4/8/64 tests cover all-defined, mixed-defined (where defined-low forces low under AND, defined-high forces high under OR, undefined propagates under XOR), and the all-undefined invariant. A defensive test confirms each op masks out-of-width payload bits to zero.

Stage S1.1 of the multi-bit wires language extension. See [`DOCS/plan-multi-bit-language.md`](https://github.com/jeffersonmourak/circ-compiler/blob/main/DOCS/plan-multi-bit-language.md) for the full plan and #18 for the parent stage.

## Test plan

- [x] `zig build test` passes (engine + topology + validator suites)
- [x] No existing tests modified; existing scalar tests still pass byte-identical
- [x] New tests exercise all three ops at widths 1, 4, 8, 64
- [x] Width=1 equivalence proof (`BitVecState: bitAnd width=1 matches the engine's AND predicate`) holds across the 3x3 three-state combinations
- [x] Defensive out-of-width masking test confirms no result has bits set beyond `widthMask(width)`

## Locked design decisions touched by this PR

From the S1 breakdown discussion:

- **Three-state semantics** (locked Q4 of S1 breakdown): `bitAnd` low if either defined-low / high if both defined-high / undefined otherwise; `bitOr` dual; `bitXor` defined iff both defined.
- **Width-agnostic** within `MAX_WIDTH = 64`; all three ops assert `self.width == other.width` and apply `widthMask` to result bitmaps so `equals` canonicality is preserved.

Out of scope for this PR (later sub-issues of #18):
- Pool generalization (S1.2, #31)
- Multi-tier Circuit pools + `createComponent` width parameter (S1.3, #32)
- Gate evaluator rewrite + bench milestone (S1.4, #33, closes #18)

Closes #30.