### PR TITLE
S1.2: Pool generalization (width-agnostic storage)

### DIFF
--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -361,14 +361,21 @@ fn tierIndexForWidth(width: u8) u8 {
     @panic("widths > 1 not wired yet; see issue #11 follow-up");
 }
 
-/// Width-tiered Structure-of-Arrays pool for wire state. For width=1, the
-/// pool packs 64 slots per `u64` word across two parallel buffers (one for
-/// value bits, one for defined bits). Reads and writes are direct bitmap
-/// operations; growth appends one `u64` to each buffer every 64 slots.
+/// Width-tiered Structure-of-Arrays pool for wire state. The storage layout
+/// switches on `width`:
+///
+/// * **width = 1**: bit-packed, 64 slots per `u64` word across two parallel
+///   buffers (one for value bits, one for defined bits). Growth appends one
+///   `u64` to each buffer every 64 slots.
+/// * **widths 2..=64**: one `u64` per slot in each buffer. Reads return the
+///   slot's full `u64` directly; writes mask to `widthMask(width)` so
+///   out-of-width payload bits stay zero, and undefined bits are
+///   canonicalized to value=0 to preserve the invariant `BitVecState.equals`
+///   relies on.
 ///
 /// The two buffers grow together; `allocateSlot` is the only growth site
-/// and it always appends to both, so length-mismatch is structurally
-/// impossible.
+/// and always appends to both, so length-mismatch is structurally impossible
+/// regardless of width.
 pub const Pool = struct {
     width: u8,
     next_slot: u32 = 0,
@@ -376,7 +383,7 @@ pub const Pool = struct {
     defined: std.ArrayList(u64) = .{},
 
     pub fn init(width: u8) Pool {
-        std.debug.assert(width == 1);
+        std.debug.assert(width >= 1 and width <= MAX_WIDTH);
         return .{ .width = width };
     }
 
@@ -387,7 +394,9 @@ pub const Pool = struct {
 
     pub fn allocateSlot(self: *Pool) !u32 {
         const slot = self.next_slot;
-        const word_idx: usize = @intCast(slot / 64);
+        // Width=1 packs 64 slots per word; wider widths use one slot per word.
+        const slots_per_word: u32 = if (self.width == 1) 64 else 1;
+        const word_idx: usize = @intCast(slot / slots_per_word);
         if (word_idx >= self.values.items.len) {
             try self.values.append(memory.allocator, 0);
             try self.defined.append(memory.allocator, 0);
@@ -397,34 +406,51 @@ pub const Pool = struct {
     }
 
     pub fn read(self: *const Pool, slot: u32) BitVecState {
-        std.debug.assert(self.width == 1);
-        const word_idx: usize = @intCast(slot / 64);
-        const bit_idx: u6 = @intCast(slot % 64);
-        const v: u64 = (self.values.items[word_idx] >> bit_idx) & 1;
-        const d: u64 = (self.defined.items[word_idx] >> bit_idx) & 1;
-        return .{ .value = v, .defined = d, .width = 1 };
+        if (self.width == 1) {
+            const word_idx: usize = @intCast(slot / 64);
+            const bit_idx: u6 = @intCast(slot % 64);
+            const v: u64 = (self.values.items[word_idx] >> bit_idx) & 1;
+            const d: u64 = (self.defined.items[word_idx] >> bit_idx) & 1;
+            return .{ .value = v, .defined = d, .width = 1 };
+        }
+        const idx: usize = @intCast(slot);
+        return .{
+            .value = self.values.items[idx],
+            .defined = self.defined.items[idx],
+            .width = self.width,
+        };
     }
 
     pub fn write(self: *Pool, slot: u32, state: BitVecState) void {
-        std.debug.assert(self.width == 1);
-        std.debug.assert(state.width == 1);
-        const word_idx: usize = @intCast(slot / 64);
-        const bit_idx: u6 = @intCast(slot % 64);
-        const mask: u64 = @as(u64, 1) << bit_idx;
-        if ((state.defined & 1) != 0) {
-            self.defined.items[word_idx] |= mask;
-            if ((state.value & 1) != 0) {
-                self.values.items[word_idx] |= mask;
+        std.debug.assert(state.width == self.width);
+        if (self.width == 1) {
+            const word_idx: usize = @intCast(slot / 64);
+            const bit_idx: u6 = @intCast(slot % 64);
+            const mask: u64 = @as(u64, 1) << bit_idx;
+            if ((state.defined & 1) != 0) {
+                self.defined.items[word_idx] |= mask;
+                if ((state.value & 1) != 0) {
+                    self.values.items[word_idx] |= mask;
+                } else {
+                    self.values.items[word_idx] &= ~mask;
+                }
             } else {
+                // Undefined: clear both bits so reads canonicalize to value=0
+                // (matters for `BitVecState.equals`, which only masks `value`
+                // by `defined` and so could otherwise carry stale payload).
+                self.defined.items[word_idx] &= ~mask;
                 self.values.items[word_idx] &= ~mask;
             }
-        } else {
-            // Undefined: clear both bits so reads canonicalize to value=0
-            // (matters for `BitVecState.equals`, which only masks `value` by
-            // `defined` and so could otherwise carry stale payload bits).
-            self.defined.items[word_idx] &= ~mask;
-            self.values.items[word_idx] &= ~mask;
+            return;
         }
+        // Widths 2..=64: one u64 per slot. Mask to `widthMask` so out-of-width
+        // payload stays zero. `value & defined` implicitly canonicalizes
+        // undefined bits to value=0 (any "1" outside the defined mask is
+        // cleared), keeping reads consistent with the equals() invariant.
+        const idx: usize = @intCast(slot);
+        const m = widthMask(self.width);
+        self.values.items[idx] = state.value & state.defined & m;
+        self.defined.items[idx] = state.defined & m;
     }
 };
 
@@ -924,6 +950,26 @@ test "Pool: undefined writes clear both value and defined bits" {
     try std.testing.expectEqual(@as(u64, 0), got.value);
     try std.testing.expectEqual(@as(u64, 0), got.defined);
     try std.testing.expect(got.equals(BitVecState.undefined_(1)));
+}
+
+test "Pool: width 4 round-trip smoke test" {
+    // Smallest path through the new width > 1 storage: allocate a slot,
+    // observe its initial undefined state, write low / high / undefined,
+    // confirm read-back equals each write.
+    var pool = Pool.init(4);
+    defer pool.deinit();
+
+    const s = try pool.allocateSlot();
+    try std.testing.expect(pool.read(s).equals(BitVecState.undefined_(4)));
+
+    pool.write(s, BitVecState.low(4));
+    try std.testing.expect(pool.read(s).equals(BitVecState.low(4)));
+
+    pool.write(s, BitVecState.high(4));
+    try std.testing.expect(pool.read(s).equals(BitVecState.high(4)));
+
+    pool.write(s, BitVecState.undefined_(4));
+    try std.testing.expect(pool.read(s).equals(BitVecState.undefined_(4)));
 }
 
 test "Circuit: allocateStateSlot returns tier-0 handle and round-trips" {

--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -972,6 +972,106 @@ test "Pool: width 4 round-trip smoke test" {
     try std.testing.expect(pool.read(s).equals(BitVecState.undefined_(4)));
 }
 
+test "Pool: round-trip at widths 4, 8, 64" {
+    // Parameterized round-trip: undefined -> low -> high -> undefined for
+    // each of the canonical wider widths. `inline for` unrolls so each
+    // width sees its own comptime-bound Pool.init call.
+    inline for (.{ 4, 8, 64 }) |w| {
+        var pool = Pool.init(w);
+        defer pool.deinit();
+
+        const s = try pool.allocateSlot();
+        try std.testing.expect(pool.read(s).equals(BitVecState.undefined_(w)));
+
+        pool.write(s, BitVecState.low(w));
+        try std.testing.expect(pool.read(s).equals(BitVecState.low(w)));
+
+        pool.write(s, BitVecState.high(w));
+        try std.testing.expect(pool.read(s).equals(BitVecState.high(w)));
+
+        pool.write(s, BitVecState.undefined_(w));
+        try std.testing.expect(pool.read(s).equals(BitVecState.undefined_(w)));
+    }
+}
+
+test "Pool: width 4 stores mixed defined/undefined patterns" {
+    var pool = Pool.init(4);
+    defer pool.deinit();
+
+    const s = try pool.allocateSlot();
+    // Per-bit (LSB first): hi, undef, lo, hi -> value=0b1001, defined=0b1101
+    const mixed = BitVecState{ .value = 0b1001, .defined = 0b1101, .width = 4 };
+    pool.write(s, mixed);
+
+    const got = pool.read(s);
+    try std.testing.expectEqual(@as(u64, 0b1001), got.value);
+    try std.testing.expectEqual(@as(u64, 0b1101), got.defined);
+    try std.testing.expectEqual(@as(u8, 4), got.width);
+}
+
+test "Pool: widths > 1 allocate one u64 per slot and isolate writes" {
+    var pool = Pool.init(8);
+    defer pool.deinit();
+
+    var slots: [10]u32 = undefined;
+    for (&slots, 0..) |*s, i| {
+        s.* = try pool.allocateSlot();
+        try std.testing.expectEqual(@as(u32, @intCast(i)), s.*);
+    }
+
+    // Ten slots -> ten u64s in each buffer (one per slot, no packing).
+    // At width=1 the same ten slots would share one u64; this confirms
+    // the wider storage path is selected.
+    try std.testing.expectEqual(@as(usize, 10), pool.values.items.len);
+    try std.testing.expectEqual(@as(usize, 10), pool.defined.items.len);
+
+    // Distinct writes to different slots must not interfere.
+    for (slots, 0..) |s, i| {
+        pool.write(s, BitVecState{ .value = @intCast(i), .defined = 0xFF, .width = 8 });
+    }
+    for (slots, 0..) |s, i| {
+        const got = pool.read(s);
+        try std.testing.expectEqual(@as(u64, @intCast(i)), got.value);
+        try std.testing.expectEqual(@as(u64, 0xFF), got.defined);
+    }
+}
+
+test "Pool: widths > 1 write canonicalizes undefined and out-of-width bits" {
+    var pool = Pool.init(4);
+    defer pool.deinit();
+
+    const s = try pool.allocateSlot();
+
+    // Dirty input: bit 1 is undefined (defined=0) but its value bit is set;
+    // bits beyond width 4 are also set in both buffers. Canonical form has
+    // undefined positions cleared from value, and bits >= 4 cleared in both.
+    //   input    value=0b111011, defined=0b111101, width=4
+    //   canonical value=0b001001, defined=0b001101
+    const dirty = BitVecState{ .value = 0b111011, .defined = 0b111101, .width = 4 };
+    pool.write(s, dirty);
+
+    const got = pool.read(s);
+    try std.testing.expectEqual(@as(u64, 0), got.value & ~widthMask(4));
+    try std.testing.expectEqual(@as(u64, 0), got.defined & ~widthMask(4));
+    try std.testing.expectEqual(@as(u64, 0b1001), got.value);
+    try std.testing.expectEqual(@as(u64, 0b1101), got.defined);
+}
+
+test "Pool: widths > 1 undefined overwrite clears both buffers" {
+    var pool = Pool.init(8);
+    defer pool.deinit();
+
+    const s = try pool.allocateSlot();
+    pool.write(s, BitVecState.high(8));
+    try std.testing.expect(pool.read(s).equals(BitVecState.high(8)));
+
+    pool.write(s, BitVecState.undefined_(8));
+    const got = pool.read(s);
+    try std.testing.expectEqual(@as(u64, 0), got.value);
+    try std.testing.expectEqual(@as(u64, 0), got.defined);
+    try std.testing.expect(got.equals(BitVecState.undefined_(8)));
+}
+
 test "Circuit: allocateStateSlot returns tier-0 handle and round-trips" {
     var circuit = try Circuit.init();
     defer circuit.deinit();


### PR DESCRIPTION
## Summary

- Drops `Pool`'s `width == 1` assertions on `init`, `read`, and `write`. Adds a storage path for widths 2..=64 using one `u64` per slot; width=1 keeps the existing bit-packed layout (64 slots per u64).
- Each method dispatches on `self.width == 1` and takes the corresponding path. The width=1 path is byte-identical to the previous implementation; existing scalar tests pass unchanged.
- The new path canonicalizes undefined bits to value=0 via `value & defined & widthMask(width)`, masking out both undefined-position payload and out-of-width bits in one expression. Mirrors the width=1 canonicalization behavior.

Stage S1.2 of the multi-bit wires language extension. See [`DOCS/plan-multi-bit-language.md`](https://github.com/jeffersonmourak/circ-compiler/blob/main/DOCS/plan-multi-bit-language.md) for the full plan and #18 for the parent stage.

## Test plan

- [x] `zig build test` passes (engine + topology + validator suites)
- [x] Existing `Pool: width=1 ...` tests pass byte-identical (regression check on the dispatched width=1 path)
- [x] New tests exercise widths 4, 8, 64 (round-trip, mixed defined/undefined, slot isolation, canonicalization, out-of-width masking)
- [x] `inline for` parameterized round-trip unrolls correctly at comptime

## Locked design decisions touched by this PR

From the S1 breakdown discussion:

- **Pool storage for widths 2..=64** (locked Q1): one `u64` per slot, regardless of actual width. Simple and predictable; bit-packing per-tier is a future optimization.

Out of scope for this PR (later sub-issues of #18):
- Multi-tier Circuit pools + `createComponent` width parameter (S1.3, #32). `tierIndexForWidth` still panics for widths > 1, so no caller can yet construct a non-1 Pool through the Circuit API.
- Gate evaluator rewrite + bench milestone (S1.4, #33, closes #18).

Closes #31.