### PR TITLE
S1.3: Multi-tier Circuit pools + createComponent width parameter

### DIFF
--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -585,12 +585,12 @@ pub const Circuit = struct {
         }
     }
 
-    pub fn createComponent(self: *Circuit, kind: Component.Kind) !*Component {
+    pub fn createComponent(self: *Circuit, kind: Component.Kind, width: u8) !*Component {
         const new_component = try Component.init(self.next_id, kind);
         // Allocate the state slot before the component is published to
         // `nodes`, so `deinit` (which never sees an in-flight component)
         // does not have to special-case the half-constructed state.
-        new_component.state_handle = try self.allocateStateSlot(1);
+        new_component.state_handle = try self.allocateStateSlot(width);
         self.next_id += 1;
         try self.nodes.append(memory.allocator, new_component);
         return new_component;
@@ -775,8 +775,8 @@ test "output_pin: passes input through" {
         var circuit = try Circuit.init();
         defer circuit.deinit();
 
-        const input = try circuit.createComponent(.{ .input_pin_gate = .{} });
-        const output_pin = try circuit.createComponent(.{ .output_pin = .{} });
+        const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+        const output_pin = try circuit.createComponent(.{ .output_pin = .{} }, 1);
         try circuit.connect(input.port(OUT_PORT_NAME), output_pin.port(OUTPUT_PIN_IN_PORT_NAME));
 
         try circuit.propagateEvent(input, BitVecState.low(1));
@@ -789,8 +789,8 @@ test "output_pin: passes input through" {
         var circuit = try Circuit.init();
         defer circuit.deinit();
 
-        const input = try circuit.createComponent(.{ .input_pin_gate = .{} });
-        const output_pin = try circuit.createComponent(.{ .output_pin = .{} });
+        const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+        const output_pin = try circuit.createComponent(.{ .output_pin = .{} }, 1);
         try circuit.connect(input.port(OUT_PORT_NAME), output_pin.port(OUTPUT_PIN_IN_PORT_NAME));
 
         try circuit.propagateEvent(input, BitVecState.high(1));
@@ -803,8 +803,8 @@ test "output_pin: passes input through" {
         var circuit = try Circuit.init();
         defer circuit.deinit();
 
-        const input = try circuit.createComponent(.{ .input_pin_gate = .{} });
-        const output_pin = try circuit.createComponent(.{ .output_pin = .{} });
+        const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+        const output_pin = try circuit.createComponent(.{ .output_pin = .{} }, 1);
         try circuit.connect(input.port(OUT_PORT_NAME), output_pin.port(OUTPUT_PIN_IN_PORT_NAME));
 
         try circuit.propagateEvent(input, BitVecState.undefined_(1));
@@ -817,8 +817,8 @@ test "output_pin: passes input through" {
         var circuit = try Circuit.init();
         defer circuit.deinit();
 
-        const input = try circuit.createComponent(.{ .input_pin_gate = .{} });
-        const output_pin = try circuit.createComponent(.{ .output_pin = .{} });
+        const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+        const output_pin = try circuit.createComponent(.{ .output_pin = .{} }, 1);
         try circuit.connect(input.port(OUT_PORT_NAME), output_pin.port(OUTPUT_PIN_IN_PORT_NAME));
 
         try circuit.propagateEvent(input, BitVecState.low(1));
@@ -834,9 +834,9 @@ test "output_pin: passes input through" {
         var circuit = try Circuit.init();
         defer circuit.deinit();
 
-        const input = try circuit.createComponent(.{ .input_pin_gate = .{} });
-        const output_pin_1 = try circuit.createComponent(.{ .output_pin = .{} });
-        const output_pin_2 = try circuit.createComponent(.{ .output_pin = .{} });
+        const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+        const output_pin_1 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
+        const output_pin_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
         try circuit.connect(input.port(OUT_PORT_NAME), output_pin_1.port(OUTPUT_PIN_IN_PORT_NAME));
         try circuit.connect(output_pin_1.port(OUTPUT_PIN_OUT_PORT_NAME), output_pin_2.port(OUTPUT_PIN_IN_PORT_NAME));
 
@@ -851,8 +851,8 @@ test "output_pin: passes input through" {
         var circuit = try Circuit.init();
         defer circuit.deinit();
 
-        const upstream = try circuit.createComponent(.{ .input_pin_gate = .{} });
-        const downstream = try circuit.createComponent(.{ .input_pin_gate = .{} });
+        const upstream = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+        const downstream = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
         try circuit.connect(upstream.port(OUT_PORT_NAME), downstream.port(IN_PORT_NAME));
 
         try circuit.propagateEvent(upstream, BitVecState.low(1));
@@ -867,9 +867,9 @@ test "led: registers out port and drives downstream output_pin" {
     var circuit = try Circuit.init();
     defer circuit.deinit();
 
-    const input = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const led = try circuit.createComponent(.{ .led = .{} });
-    const output_pin = try circuit.createComponent(.{ .output_pin = .{} });
+    const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const led = try circuit.createComponent(.{ .led = .{} }, 1);
+    const output_pin = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(input.port(OUT_PORT_NAME), led.port(IN_PORT_NAME));
     try circuit.connect(led.port(OUT_PORT_NAME), output_pin.port(OUTPUT_PIN_IN_PORT_NAME));
 
@@ -1365,9 +1365,9 @@ test "engine: pool view tracks state across a propagation chain" {
     var circuit = try Circuit.init();
     defer circuit.deinit();
 
-    const input = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const not_gate = try circuit.createComponent(.{ .not_gate = .{} });
-    const out = try circuit.createComponent(.{ .output_pin = .{} });
+    const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const not_gate = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const out = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(input.port(OUT_PORT_NAME), not_gate.port(IN_PORT_NAME));
     try circuit.connect(not_gate.port(OUT_PORT_NAME), out.port(OUTPUT_PIN_IN_PORT_NAME));
 
@@ -1394,7 +1394,7 @@ test "engine: pool slot indices are dense and unique" {
 
     var ids: [70]u32 = undefined;
     for (&ids, 0..) |*slot, i| {
-        const comp = try circuit.createComponent(.{ .wire = .{} });
+        const comp = try circuit.createComponent(.{ .wire = .{} }, 1);
         slot.* = comp.state_handle.slot;
         try std.testing.expectEqual(@as(u32, @intCast(i)), slot.*);
         // Width=1 components live in tier 1 under the `tier = width` rule.

--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -1355,6 +1355,103 @@ test "Circuit: allocateStateSlot returns a tier=width handle and round-trips" {
     try std.testing.expect(circuit.readState(h2).equals(BitVecState.low(1)));
 }
 
+test "Circuit: createComponent at widths 4, 8, 64 lands in the matching tier" {
+    inline for (.{ 4, 8, 64 }) |w| {
+        var circuit = try Circuit.init();
+        defer circuit.deinit();
+
+        const comp = try circuit.createComponent(.{ .wire = .{} }, w);
+        // Handle's tier equals the requested width under `tier = width`.
+        try std.testing.expectEqual(@as(u8, w), comp.state_handle.tier);
+        try std.testing.expectEqual(@as(u32, 0), comp.state_handle.slot);
+        // Initial state is undefined at the requested width.
+        try std.testing.expect(circuit.readState(comp.state_handle).equals(BitVecState.undefined_(w)));
+
+        // Round-trip a defined value to confirm the slot dispatches to the
+        // right pool's storage on both read and write.
+        circuit.writeState(comp.state_handle, BitVecState.high(w));
+        try std.testing.expect(circuit.readState(comp.state_handle).equals(BitVecState.high(w)));
+    }
+}
+
+test "Circuit: mixed-width components allocate in independent tiers" {
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    const scalar = try circuit.createComponent(.{ .wire = .{} }, 1);
+    const bus4 = try circuit.createComponent(.{ .wire = .{} }, 4);
+    const bus8 = try circuit.createComponent(.{ .wire = .{} }, 8);
+    const scalar2 = try circuit.createComponent(.{ .wire = .{} }, 1);
+
+    // Each width gets its own tier; same-width components share a tier
+    // and receive dense slot indices within it.
+    try std.testing.expectEqual(@as(u8, 1), scalar.state_handle.tier);
+    try std.testing.expectEqual(@as(u32, 0), scalar.state_handle.slot);
+    try std.testing.expectEqual(@as(u8, 4), bus4.state_handle.tier);
+    try std.testing.expectEqual(@as(u32, 0), bus4.state_handle.slot);
+    try std.testing.expectEqual(@as(u8, 8), bus8.state_handle.tier);
+    try std.testing.expectEqual(@as(u32, 0), bus8.state_handle.slot);
+    try std.testing.expectEqual(@as(u8, 1), scalar2.state_handle.tier);
+    try std.testing.expectEqual(@as(u32, 1), scalar2.state_handle.slot);
+
+    // Writes to one tier must not bleed into another.
+    circuit.writeState(scalar.state_handle, BitVecState.high(1));
+    circuit.writeState(bus4.state_handle, BitVecState{ .value = 0b1010, .defined = 0b1111, .width = 4 });
+    circuit.writeState(bus8.state_handle, BitVecState.low(8));
+    circuit.writeState(scalar2.state_handle, BitVecState.low(1));
+
+    try std.testing.expect(circuit.readState(scalar.state_handle).equals(BitVecState.high(1)));
+    try std.testing.expectEqual(@as(u64, 0b1010), circuit.readState(bus4.state_handle).value);
+    try std.testing.expectEqual(@as(u64, 0b1111), circuit.readState(bus4.state_handle).defined);
+    try std.testing.expect(circuit.readState(bus8.state_handle).equals(BitVecState.low(8)));
+    try std.testing.expect(circuit.readState(scalar2.state_handle).equals(BitVecState.low(1)));
+}
+
+test "Circuit: lazy tier init only allocates tiers actually used" {
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    // Empty Circuit: every tier slot is null.
+    for (circuit.tiers) |maybe_pool| {
+        try std.testing.expect(maybe_pool == null);
+    }
+
+    // After allocating at width 4: only tier 4 exists.
+    _ = try circuit.createComponent(.{ .wire = .{} }, 4);
+    try std.testing.expect(circuit.tiers[4] != null);
+    try std.testing.expect(circuit.tiers[1] == null);
+    try std.testing.expect(circuit.tiers[8] == null);
+    try std.testing.expect(circuit.tiers[64] == null);
+    // Tier 0 stays null forever (reserved/unused under `tier = width`).
+    try std.testing.expect(circuit.tiers[0] == null);
+
+    // After allocating at width 1: tiers 1 and 4 exist; others still null.
+    _ = try circuit.createComponent(.{ .wire = .{} }, 1);
+    try std.testing.expect(circuit.tiers[1] != null);
+    try std.testing.expect(circuit.tiers[4] != null);
+    try std.testing.expect(circuit.tiers[8] == null);
+    try std.testing.expect(circuit.tiers[64] == null);
+}
+
+test "Circuit: deinit frees every allocated tier with mixed widths" {
+    // Build a Circuit that touches four different tiers, then deinit.
+    // Zig's debug allocator catches double-frees and leaks at scope exit;
+    // a clean test pass here is the evidence that deinit walks every
+    // non-null tier and frees its ArrayLists.
+    var circuit = try Circuit.init();
+    _ = try circuit.createComponent(.{ .wire = .{} }, 1);
+    _ = try circuit.createComponent(.{ .wire = .{} }, 4);
+    _ = try circuit.createComponent(.{ .wire = .{} }, 8);
+    _ = try circuit.createComponent(.{ .wire = .{} }, 64);
+    // Force allocator growth in each tier so deinit has buffers to free.
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = try circuit.createComponent(.{ .wire = .{} }, 4);
+        _ = try circuit.createComponent(.{ .wire = .{} }, 8);
+    }
+    circuit.deinit();
+}
+
 // ============================================================================
 // End-to-end engine tests over the BitVecState / pool surface. State lives
 // exclusively in the per-tier SoA pool; `Circuit.createComponent` allocates

--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -398,13 +398,12 @@ pub const PoolHandle = struct {
     slot: u32,
 };
 
-/// Maps a width to the index of the pool that owns it. Only width=1 (tier 0)
-/// is wired today; wider widths panic with a pointer back to the follow-up
-/// issue. Adding a tier in the future is purely additive here.
+/// Maps a width to the index of the pool that owns it. Convention: tier
+/// number equals width number, so `Circuit.tiers[width]` is the canonical
+/// pool lookup. Tier 0 is reserved/unused; legal widths are 1..=MAX_WIDTH.
 fn tierIndexForWidth(width: u8) u8 {
     std.debug.assert(width >= 1 and width <= MAX_WIDTH);
-    if (width == 1) return 0;
-    @panic("widths > 1 not wired yet; see issue #11 follow-up");
+    return width;
 }
 
 /// Width-tiered Structure-of-Arrays pool for wire state. The storage layout
@@ -511,12 +510,13 @@ pub const Circuit = struct {
     /// from zero capacity; instead the previous run's capacity is retained
     /// (length reset to 0 at the end of each per-timestamp iteration).
     changed_at_step: std.ArrayList(*Component) = .{},
-    /// Width-tiered SoA pool for wire state. Today only tier 1 (width=1) is
-    /// exercised; the field is a single `Pool` rather than `[N]Pool` because
-    /// nothing else has storage yet. The next issue widens this into an
-    /// array indexed by `PoolHandle.tier` once wider widths land in the
-    /// language surface and the topology format.
-    tier1: Pool = Pool.init(1),
+    /// Width-tiered SoA pool array indexed by tier number (tier N owns
+    /// width-N state slots). Tier 0 is reserved/unused; the convention
+    /// `tier = width` makes `tiers[handle.tier]` the canonical lookup for
+    /// any state. Each tier is allocated lazily by `getOrInitTier` on its
+    /// first use, so a single-bit circuit pays for only one Pool rather
+    /// than `MAX_WIDTH + 1` of them.
+    tiers: [MAX_WIDTH + 1]?Pool = [_]?Pool{null} ** (MAX_WIDTH + 1),
     /// Benchmark counters. Present only when `COLLECT_METRICS` is true so
     /// shipping builds carry zero bytes and zero instructions for the
     /// metrics path. The conditional type is `void` (zero-sized) otherwise,
@@ -530,7 +530,6 @@ pub const Circuit = struct {
             .event_queue = EventQueue.init(),
             .listener = null,
             .changed_at_step = .{},
-            .tier1 = Pool.init(1),
             .metrics = if (COLLECT_METRICS) Metrics{} else {},
         };
     }
@@ -542,38 +541,42 @@ pub const Circuit = struct {
         self.nodes.deinit(memory.allocator);
         self.event_queue.deinit();
         self.changed_at_step.deinit(memory.allocator);
-        self.tier1.deinit();
+        for (&self.tiers) |*maybe_pool| {
+            if (maybe_pool.* != null) maybe_pool.*.?.deinit();
+        }
+    }
+
+    /// Returns the pool that owns `width`, allocating it lazily on first
+    /// access. Cheap when the pool already exists (one null check); one
+    /// `Pool.init` plus an optional store otherwise.
+    fn getOrInitTier(self: *Circuit, width: u8) *Pool {
+        const tier = tierIndexForWidth(width);
+        if (self.tiers[tier] == null) {
+            self.tiers[tier] = Pool.init(width);
+        }
+        return &self.tiers[tier].?;
     }
 
     /// Allocate a fresh state slot in the pool that owns `width`. Returns
     /// the opaque handle that future `readState`/`writeState` calls use.
-    /// Today only width=1 is legal; wider widths trap via the dispatcher.
     pub fn allocateStateSlot(self: *Circuit, width: u8) !PoolHandle {
         const tier = tierIndexForWidth(width);
-        const slot = switch (tier) {
-            0 => try self.tier1.allocateSlot(),
-            else => unreachable,
-        };
+        const pool = self.getOrInitTier(width);
+        const slot = try pool.allocateSlot();
         return .{ .tier = tier, .slot = slot };
     }
 
     /// Read the BitVecState at `handle`. Tier dispatch happens exactly once;
     /// everything above this line sees only the value type.
     pub fn readState(self: *const Circuit, handle: PoolHandle) BitVecState {
-        return switch (handle.tier) {
-            0 => self.tier1.read(handle.slot),
-            else => unreachable,
-        };
+        return self.tiers[handle.tier].?.read(handle.slot);
     }
 
     /// Write `state` to the slot at `handle`. The caller is responsible for
     /// the `state.width == pool.width` invariant; debug-mode asserts inside
     /// the pool catch mismatches.
     pub fn writeState(self: *Circuit, handle: PoolHandle, state: BitVecState) void {
-        switch (handle.tier) {
-            0 => self.tier1.write(handle.slot, state),
-            else => unreachable,
-        }
+        self.tiers[handle.tier].?.write(handle.slot, state);
     }
 
     pub fn notifyStateChange(self: *Circuit, component: *Component, new_state: BitVecState) void {
@@ -1332,15 +1335,17 @@ test "Pool: widths > 1 undefined overwrite clears both buffers" {
     try std.testing.expect(got.equals(BitVecState.undefined_(8)));
 }
 
-test "Circuit: allocateStateSlot returns tier-0 handle and round-trips" {
+test "Circuit: allocateStateSlot returns a tier=width handle and round-trips" {
     var circuit = try Circuit.init();
     defer circuit.deinit();
 
     const h1 = try circuit.allocateStateSlot(1);
     const h2 = try circuit.allocateStateSlot(1);
-    try std.testing.expectEqual(@as(u8, 0), h1.tier);
+    // Width=1 now lives in tier 1 (the convention `tier = width`); tier 0
+    // is reserved/unused.
+    try std.testing.expectEqual(@as(u8, 1), h1.tier);
     try std.testing.expectEqual(@as(u32, 0), h1.slot);
-    try std.testing.expectEqual(@as(u8, 0), h2.tier);
+    try std.testing.expectEqual(@as(u8, 1), h2.tier);
     try std.testing.expectEqual(@as(u32, 1), h2.slot);
 
     try std.testing.expect(circuit.readState(h1).equals(BitVecState.undefined_(1)));
@@ -1392,11 +1397,12 @@ test "engine: pool slot indices are dense and unique" {
         const comp = try circuit.createComponent(.{ .wire = .{} });
         slot.* = comp.state_handle.slot;
         try std.testing.expectEqual(@as(u32, @intCast(i)), slot.*);
-        try std.testing.expectEqual(@as(u8, 0), comp.state_handle.tier);
+        // Width=1 components live in tier 1 under the `tier = width` rule.
+        try std.testing.expectEqual(@as(u8, 1), comp.state_handle.tier);
     }
 
     // Slot 64 crossed the first word boundary; confirm the second word
-    // actually exists on both buffers.
-    try std.testing.expect(circuit.tier1.values.items.len >= 2);
-    try std.testing.expect(circuit.tier1.defined.items.len >= 2);
+    // actually exists on both buffers of the lazily-initialized tier-1 pool.
+    try std.testing.expect(circuit.tiers[1].?.values.items.len >= 2);
+    try std.testing.expect(circuit.tiers[1].?.defined.items.len >= 2);
 }

--- a/lib/emit/build_fn.zig
+++ b/lib/emit/build_fn.zig
@@ -77,7 +77,7 @@ pub fn emitBuildFunction(allocator: std.mem.Allocator, module: *const ir.Module)
             .sub_circuit_ref => return error.UnsupportedSubCircuitInPhase4,
             .unresolved_name => return error.UnresolvedComponentName,
         };
-        try writer.writeLineFmt("const {s} = try circuit.createComponent({s});", .{ var_name, expr });
+        try writer.writeLineFmt("const {s} = try circuit.createComponent({s}, 1);", .{ var_name, expr });
     }
 
     for (module.connections) |connection| {

--- a/lib/emit/project.zig
+++ b/lib/emit/project.zig
@@ -327,7 +327,7 @@ fn emitFileBuildFunction(
                 const var_name = try componentVarName(allocator, writer, component);
                 defer allocator.free(var_name);
                 try writer.writeLineFmt(
-                    "const {s} = try circuit.createComponent({s});",
+                    "const {s} = try circuit.createComponent({s}, 1);",
                     .{ var_name, primitiveExpr(primitive) },
                 );
             },

--- a/lib/transport.zig
+++ b/lib/transport.zig
@@ -58,7 +58,7 @@ test "transport: encodes output_pin state" {
     var circuit = try Circuit.init();
     defer circuit.deinit();
 
-    const output_pin = try circuit.createComponent(.{ .output_pin = .{} });
+    const output_pin = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     const state = circuit.readState(output_pin.state_handle);
     const encoded = try encodeState(output_pin, state).encode(std.testing.allocator);
     defer std.testing.allocator.free(encoded);

--- a/lib/truth_table/builder.zig
+++ b/lib/truth_table/builder.zig
@@ -122,12 +122,12 @@ pub fn build(
     try id_to_node.ensureTotalCapacity(@intCast(topology.components.len));
     for (topology.components) |comp| {
         const node = switch (comp.kind) {
-            .input_pin => circuit.createComponent(.{ .input_pin_gate = .{} }),
-            .not_gate => circuit.createComponent(.{ .not_gate = .{} }),
-            .and_gate => circuit.createComponent(.{ .and_gate = .{} }),
-            .wire => circuit.createComponent(.{ .wire = .{} }),
-            .led => circuit.createComponent(.{ .led = .{} }),
-            .output_pin => circuit.createComponent(.{ .output_pin = .{} }),
+            .input_pin => circuit.createComponent(.{ .input_pin_gate = .{} }, 1),
+            .not_gate => circuit.createComponent(.{ .not_gate = .{} }, 1),
+            .and_gate => circuit.createComponent(.{ .and_gate = .{} }, 1),
+            .wire => circuit.createComponent(.{ .wire = .{} }, 1),
+            .led => circuit.createComponent(.{ .led = .{} }, 1),
+            .output_pin => circuit.createComponent(.{ .output_pin = .{} }, 1),
         } catch return error.InvalidTopology;
         node.id = comp.id;
         id_to_node.putAssumeCapacity(comp.id, node);

--- a/templates/interpreter.zig
+++ b/templates/interpreter.zig
@@ -45,12 +45,12 @@ pub fn initFromTopology(circuit: *engine.Circuit, payload: []const u8) !void {
 
         const component_kind = std.meta.intToEnum(format.ComponentKind, kind_val) catch return error.InvalidComponentKind;
         const comp = switch (component_kind) {
-            .input_pin => try circuit.createComponent(.{ .input_pin_gate = .{} }),
-            .not_gate => try circuit.createComponent(.{ .not_gate = .{} }),
-            .and_gate => try circuit.createComponent(.{ .and_gate = .{} }),
-            .wire => try circuit.createComponent(.{ .wire = .{} }),
-            .led => try circuit.createComponent(.{ .led = .{} }),
-            .output_pin => try circuit.createComponent(.{ .output_pin = .{} }),
+            .input_pin => try circuit.createComponent(.{ .input_pin_gate = .{} }, 1),
+            .not_gate => try circuit.createComponent(.{ .not_gate = .{} }, 1),
+            .and_gate => try circuit.createComponent(.{ .and_gate = .{} }, 1),
+            .wire => try circuit.createComponent(.{ .wire = .{} }, 1),
+            .led => try circuit.createComponent(.{ .led = .{} }, 1),
+            .output_pin => try circuit.createComponent(.{ .output_pin = .{} }, 1),
         };
         comp.id = id; 
         comp_map.putAssumeCapacity(id, comp);

--- a/tests/fixtures/expected-zig/and_two_inputs.zig
+++ b/tests/fixtures/expected-zig/and_two_inputs.zig
@@ -11,10 +11,10 @@ fn buildCircuit(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_result: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_gate1_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_gate1_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_gate1_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_gate1_2.port("b"));
     try circuit.connect(comp_gate1_2.port("out"), comp_result_3.port("in"));

--- a/tests/fixtures/expected-zig/and_two_inputs_build_fn.zig
+++ b/tests/fixtures/expected-zig/and_two_inputs_build_fn.zig
@@ -3,10 +3,10 @@ fn buildCircuit(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_result: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_gate1_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_gate1_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_gate1_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_gate1_2.port("b"));
     try circuit.connect(comp_gate1_2.port("out"), comp_result_3.port("in"));

--- a/tests/fixtures/expected-zig/anonymous_nested.zig
+++ b/tests/fixtures/expected-zig/anonymous_nested.zig
@@ -10,10 +10,10 @@ fn buildCircuit(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_result: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_gate_1 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp___anon_0_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_gate_1 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp___anon_0_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp___anon_0_2.port("out"), comp_gate_1.port("a"));
     try circuit.connect(comp_a_0.port("out"), comp_gate_1.port("b"));
     try circuit.connect(comp_a_0.port("out"), comp___anon_0_2.port("in"));

--- a/tests/fixtures/expected-zig/anonymous_nested_build_fn.zig
+++ b/tests/fixtures/expected-zig/anonymous_nested_build_fn.zig
@@ -2,10 +2,10 @@ fn buildCircuit(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_result: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_gate_1 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp___anon_0_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_gate_1 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp___anon_0_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_result_3 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp___anon_0_2.port("out"), comp_gate_1.port("a"));
     try circuit.connect(comp_a_0.port("out"), comp_gate_1.port("b"));
     try circuit.connect(comp_a_0.port("out"), comp___anon_0_2.port("in"));

--- a/tests/fixtures/expected-zig/empty_ish.zig
+++ b/tests/fixtures/expected-zig/empty_ish.zig
@@ -10,8 +10,8 @@ fn buildCircuit(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_out_1.port("in"));
     return .{
         .input_a = comp_a_0,

--- a/tests/fixtures/expected-zig/empty_ish_build_fn.zig
+++ b/tests/fixtures/expected-zig/empty_ish_build_fn.zig
@@ -2,8 +2,8 @@ fn buildCircuit(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_out_1.port("in"));
     return .{
         .input_a = comp_a_0,

--- a/tests/fixtures/expected-zig/keyword_instance_name_build_fn.zig
+++ b/tests/fixtures/expected-zig/keyword_instance_name_build_fn.zig
@@ -2,9 +2,9 @@ fn buildCircuit(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_error__1 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_error__1 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_error__1.port("in"));
     try circuit.connect(comp_error__1.port("out"), comp_out_2.port("in"));
     return .{

--- a/tests/fixtures/expected-zig/projects/and_pair/main.zig
+++ b/tests/fixtures/expected-zig/projects/and_pair/main.zig
@@ -13,14 +13,14 @@ fn buildFile_0(circuit: *engine.Circuit) !struct {
     input_d: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_c_2 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_d_3 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_c_2 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_d_3 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_p1_4 = try buildFile_1(circuit);
     const inst_p2_5 = try buildFile_1(circuit);
-    const comp_combine_6 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_7 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_combine_6 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_7 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_p1_4.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_p1_4.input_b.port("in"));
     try circuit.connect(comp_c_2.port("out"), inst_p2_5.input_a.port("in"));
@@ -42,10 +42,10 @@ fn buildFile_1(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_gate_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_3 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_gate_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_3 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_gate_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_gate_2.port("b"));
     try circuit.connect(comp_gate_2.port("out"), comp_out_3.port("in"));
@@ -61,13 +61,13 @@ fn buildFile_2(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_na_2.port("in"));
     try circuit.connect(comp_b_1.port("out"), comp_nb_3.port("in"));
     try circuit.connect(comp_na_2.port("out"), comp_inner_4.port("a"));
@@ -86,11 +86,11 @@ fn buildFile_3(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_inner_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_inner_2.port("b"));
     try circuit.connect(comp_inner_2.port("out"), comp_n_3.port("in"));
@@ -107,11 +107,11 @@ fn buildFile_4(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_2(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -128,12 +128,12 @@ fn buildFile_5(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_o_2 = try buildFile_2(circuit);
     const inst_n_3 = try buildFile_3(circuit);
-    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_o_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_o_2.input_b.port("in"));
     try circuit.connect(comp_a_0.port("out"), inst_n_3.input_a.port("in"));
@@ -153,11 +153,11 @@ fn buildFile_6(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_5(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));

--- a/tests/fixtures/expected-zig/projects/deep_chain/main.zig
+++ b/tests/fixtures/expected-zig/projects/deep_chain/main.zig
@@ -10,9 +10,9 @@ fn buildFile_0(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_u_1 = try buildFile_1(circuit);
-    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_u_1.input_rin.port("in"));
     try circuit.connect(inst_u_1.output_rout.port("out"), comp_out_2.port("in"));
     return .{
@@ -25,9 +25,9 @@ fn buildFile_1(circuit: *engine.Circuit) !struct {
     input_rin: *engine.Component,
     output_rout: *engine.Component,
 } {
-    const comp_rin_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_rin_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_u_1 = try buildFile_7(circuit);
-    const comp_rout_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_rout_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_rin_0.port("out"), inst_u_1.input_tin.port("in"));
     try circuit.connect(inst_u_1.output_tout.port("out"), comp_rout_2.port("in"));
     return .{
@@ -41,13 +41,13 @@ fn buildFile_2(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_na_2.port("in"));
     try circuit.connect(comp_b_1.port("out"), comp_nb_3.port("in"));
     try circuit.connect(comp_na_2.port("out"), comp_inner_4.port("a"));
@@ -66,11 +66,11 @@ fn buildFile_3(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_inner_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_inner_2.port("b"));
     try circuit.connect(comp_inner_2.port("out"), comp_n_3.port("in"));
@@ -87,11 +87,11 @@ fn buildFile_4(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_2(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -108,12 +108,12 @@ fn buildFile_5(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_o_2 = try buildFile_2(circuit);
     const inst_n_3 = try buildFile_3(circuit);
-    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_o_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_o_2.input_b.port("in"));
     try circuit.connect(comp_a_0.port("out"), inst_n_3.input_a.port("in"));
@@ -133,11 +133,11 @@ fn buildFile_6(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_5(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -153,9 +153,9 @@ fn buildFile_7(circuit: *engine.Circuit) !struct {
     input_tin: *engine.Component,
     output_tout: *engine.Component,
 } {
-    const comp_tin_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_tin_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_u_1 = try buildFile_8(circuit);
-    const comp_tout_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_tout_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_tin_0.port("out"), inst_u_1.input_din.port("in"));
     try circuit.connect(inst_u_1.output_dout.port("out"), comp_tout_2.port("in"));
     return .{
@@ -168,9 +168,9 @@ fn buildFile_8(circuit: *engine.Circuit) !struct {
     input_din: *engine.Component,
     output_dout: *engine.Component,
 } {
-    const comp_din_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_din_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_u_1 = try buildFile_9(circuit);
-    const comp_dout_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_dout_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_din_0.port("out"), inst_u_1.input_cin.port("in"));
     try circuit.connect(inst_u_1.output_cout.port("out"), comp_dout_2.port("in"));
     return .{
@@ -183,8 +183,8 @@ fn buildFile_9(circuit: *engine.Circuit) !struct {
     input_cin: *engine.Component,
     output_cout: *engine.Component,
 } {
-    const comp_cin_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_cout_1 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_cin_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_cout_1 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_cin_0.port("out"), comp_cout_1.port("in"));
     return .{
         .input_cin = comp_cin_0,

--- a/tests/fixtures/expected-zig/projects/diamond/main.zig
+++ b/tests/fixtures/expected-zig/projects/diamond/main.zig
@@ -10,11 +10,11 @@ fn buildFile_0(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_l_1 = try buildFile_1(circuit);
     const inst_r_2 = try buildFile_2(circuit);
-    const comp_comb_3 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_comb_3 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_l_1.input_in.port("in"));
     try circuit.connect(comp_a_0.port("out"), inst_r_2.input_in.port("in"));
     try circuit.connect(inst_l_1.output_out.port("out"), comp_comb_3.port("a"));
@@ -30,9 +30,9 @@ fn buildFile_1(circuit: *engine.Circuit) !struct {
     input_in: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_in_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_in_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_b_1 = try buildFile_8(circuit);
-    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_in_0.port("out"), inst_b_1.input_in.port("in"));
     try circuit.connect(inst_b_1.output_out.port("out"), comp_out_2.port("in"));
     return .{
@@ -45,9 +45,9 @@ fn buildFile_2(circuit: *engine.Circuit) !struct {
     input_in: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_in_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_in_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_b_1 = try buildFile_8(circuit);
-    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_in_0.port("out"), inst_b_1.input_in.port("in"));
     try circuit.connect(inst_b_1.output_out.port("out"), comp_out_2.port("in"));
     return .{
@@ -61,13 +61,13 @@ fn buildFile_3(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_na_2.port("in"));
     try circuit.connect(comp_b_1.port("out"), comp_nb_3.port("in"));
     try circuit.connect(comp_na_2.port("out"), comp_inner_4.port("a"));
@@ -86,11 +86,11 @@ fn buildFile_4(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_inner_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_inner_2.port("b"));
     try circuit.connect(comp_inner_2.port("out"), comp_n_3.port("in"));
@@ -107,11 +107,11 @@ fn buildFile_5(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_3(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -128,12 +128,12 @@ fn buildFile_6(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_o_2 = try buildFile_3(circuit);
     const inst_n_3 = try buildFile_4(circuit);
-    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_o_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_o_2.input_b.port("in"));
     try circuit.connect(comp_a_0.port("out"), inst_n_3.input_a.port("in"));
@@ -153,11 +153,11 @@ fn buildFile_7(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_6(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -173,8 +173,8 @@ fn buildFile_8(circuit: *engine.Circuit) !struct {
     input_in: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_in_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_in_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_in_0.port("out"), comp_out_1.port("in"));
     return .{
         .input_in = comp_in_0,

--- a/tests/fixtures/expected-zig/projects/nested_invert/main.zig
+++ b/tests/fixtures/expected-zig/projects/nested_invert/main.zig
@@ -10,9 +10,9 @@ fn buildFile_0(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_d_1 = try buildFile_1(circuit);
-    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_d_1.input_a.port("in"));
     try circuit.connect(inst_d_1.output_out.port("out"), comp_out_2.port("in"));
     return .{
@@ -25,10 +25,10 @@ fn buildFile_1(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inv1_1 = try buildFile_7(circuit);
     const inst_inv2_2 = try buildFile_7(circuit);
-    const comp_out_3 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_out_3 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inv1_1.input_a.port("in"));
     try circuit.connect(inst_inv1_1.output_out.port("out"), inst_inv2_2.input_a.port("in"));
     try circuit.connect(inst_inv2_2.output_out.port("out"), comp_out_3.port("in"));
@@ -43,13 +43,13 @@ fn buildFile_2(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_na_2.port("in"));
     try circuit.connect(comp_b_1.port("out"), comp_nb_3.port("in"));
     try circuit.connect(comp_na_2.port("out"), comp_inner_4.port("a"));
@@ -68,11 +68,11 @@ fn buildFile_3(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_inner_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_inner_2.port("b"));
     try circuit.connect(comp_inner_2.port("out"), comp_n_3.port("in"));
@@ -89,11 +89,11 @@ fn buildFile_4(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_2(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -110,12 +110,12 @@ fn buildFile_5(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_o_2 = try buildFile_2(circuit);
     const inst_n_3 = try buildFile_3(circuit);
-    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_o_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_o_2.input_b.port("in"));
     try circuit.connect(comp_a_0.port("out"), inst_n_3.input_a.port("in"));
@@ -135,11 +135,11 @@ fn buildFile_6(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_5(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -155,9 +155,9 @@ fn buildFile_7(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_n_1 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_n_1 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_n_1.port("in"));
     try circuit.connect(comp_n_1.port("out"), comp_out_2.port("in"));
     return .{

--- a/tests/fixtures/expected-zig/projects/passthrough_chain/main.zig
+++ b/tests/fixtures/expected-zig/projects/passthrough_chain/main.zig
@@ -10,9 +10,9 @@ fn buildFile_0(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_b1_1 = try buildFile_1(circuit);
-    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_b1_1.input_a.port("in"));
     try circuit.connect(inst_b1_1.output_out.port("out"), comp_out_2.port("in"));
     return .{
@@ -25,8 +25,8 @@ fn buildFile_1(circuit: *engine.Circuit) !struct {
     input_a: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_out_1 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_out_1.port("in"));
     return .{
         .input_a = comp_a_0,
@@ -39,13 +39,13 @@ fn buildFile_2(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_na_2.port("in"));
     try circuit.connect(comp_b_1.port("out"), comp_nb_3.port("in"));
     try circuit.connect(comp_na_2.port("out"), comp_inner_4.port("a"));
@@ -64,11 +64,11 @@ fn buildFile_3(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_inner_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_inner_2.port("b"));
     try circuit.connect(comp_inner_2.port("out"), comp_n_3.port("in"));
@@ -85,11 +85,11 @@ fn buildFile_4(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_2(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -106,12 +106,12 @@ fn buildFile_5(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_o_2 = try buildFile_2(circuit);
     const inst_n_3 = try buildFile_3(circuit);
-    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_o_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_o_2.input_b.port("in"));
     try circuit.connect(comp_a_0.port("out"), inst_n_3.input_a.port("in"));
@@ -131,11 +131,11 @@ fn buildFile_6(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_5(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));

--- a/tests/fixtures/expected-zig/projects/same_name_half_adder/main.zig
+++ b/tests/fixtures/expected-zig/projects/same_name_half_adder/main.zig
@@ -11,12 +11,12 @@ fn buildFile_0(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_u1_2 = try buildFile_1(circuit);
     const inst_u2_3 = try buildFile_2(circuit);
-    const comp_comb_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_comb_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_u1_2.input_xa.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_u2_3.input_xb.port("in"));
     try circuit.connect(inst_u1_2.output_sum_out.port("out"), comp_comb_4.port("a"));
@@ -33,8 +33,8 @@ fn buildFile_1(circuit: *engine.Circuit) !struct {
     input_xa: *engine.Component,
     output_sum_out: *engine.Component,
 } {
-    const comp_xa_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_sum_out_1 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_xa_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_sum_out_1 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_xa_0.port("out"), comp_sum_out_1.port("in"));
     return .{
         .input_xa = comp_xa_0,
@@ -46,9 +46,9 @@ fn buildFile_2(circuit: *engine.Circuit) !struct {
     input_xb: *engine.Component,
     output_sum_out: *engine.Component,
 } {
-    const comp_xb_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_inv_1 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_sum_out_2 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_xb_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_inv_1 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_sum_out_2 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_xb_0.port("out"), comp_inv_1.port("in"));
     try circuit.connect(comp_inv_1.port("out"), comp_sum_out_2.port("in"));
     return .{
@@ -62,13 +62,13 @@ fn buildFile_3(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_na_2 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_nb_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_inner_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_5 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_6 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_na_2.port("in"));
     try circuit.connect(comp_b_1.port("out"), comp_nb_3.port("in"));
     try circuit.connect(comp_na_2.port("out"), comp_inner_4.port("a"));
@@ -87,11 +87,11 @@ fn buildFile_4(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_inner_2 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), comp_inner_2.port("a"));
     try circuit.connect(comp_b_1.port("out"), comp_inner_2.port("b"));
     try circuit.connect(comp_inner_2.port("out"), comp_n_3.port("in"));
@@ -108,11 +108,11 @@ fn buildFile_5(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_3(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));
@@ -129,12 +129,12 @@ fn buildFile_6(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_o_2 = try buildFile_3(circuit);
     const inst_n_3 = try buildFile_4(circuit);
-    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} });
-    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_gate_4 = try circuit.createComponent(.{ .and_gate = .{} }, 1);
+    const comp_out_5 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_o_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_o_2.input_b.port("in"));
     try circuit.connect(comp_a_0.port("out"), inst_n_3.input_a.port("in"));
@@ -154,11 +154,11 @@ fn buildFile_7(circuit: *engine.Circuit) !struct {
     input_b: *engine.Component,
     output_out: *engine.Component,
 } {
-    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} });
-    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} });
+    const comp_a_0 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const comp_b_1 = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
     const inst_inner_2 = try buildFile_6(circuit);
-    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} });
-    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} });
+    const comp_n_3 = try circuit.createComponent(.{ .not_gate = .{} }, 1);
+    const comp_out_4 = try circuit.createComponent(.{ .output_pin = .{} }, 1);
     try circuit.connect(comp_a_0.port("out"), inst_inner_2.input_a.port("in"));
     try circuit.connect(comp_b_1.port("out"), inst_inner_2.input_b.port("in"));
     try circuit.connect(inst_inner_2.output_out.port("out"), comp_n_3.port("in"));


### PR DESCRIPTION
## Summary

- Replaces `Circuit.tier1: Pool` with a fixed-size `tiers: [MAX_WIDTH + 1]?Pool` array indexed by tier number under the convention `tier = width`. Each tier is lazily initialized via a new `getOrInitTier` helper, so a single-bit circuit still allocates exactly one Pool.
- Changes `Circuit.createComponent(kind)` to `createComponent(kind, width)`. Width threads through to `allocateStateSlot`, which dispatches to the right tier. Every existing caller passes `1` explicitly (Zig has no parameter defaults).
- `tierIndexForWidth` stops panicking for widths > 1 and now returns the width directly. `readState`/`writeState` dispatch through `tiers[handle.tier].?`.
- Migration touches `lib/transport.zig`, `lib/truth_table/builder.zig`, `templates/interpreter.zig`, and the two emit templates (`lib/emit/build_fn.zig`, `lib/emit/project.zig`). The 13 `expected-zig/` snapshot fixtures were regenerated via `UPDATE_GOLDENS=1`.

Stage S1.3 of the multi-bit wires language extension. See [`DOCS/plan-multi-bit-language.md`](https://github.com/jeffersonmourak/circ-compiler/blob/main/DOCS/plan-multi-bit-language.md) for the full plan and #18 for the parent stage.

## Test plan

- [x] `zig build test` passes (engine + topology + validator + emit + integration suites)
- [x] Existing width=1 tests pass byte-identical (tier number is the only assertion change: `tier == 0` → `tier == 1`)
- [x] New tests construct components at widths 4, 8, 64; verify state slot allocation and round-trip
- [x] Mixed-width Circuit: independent tiers, dense per-tier slot indices, write isolation across tiers
- [x] Lazy tier init: empty Circuit has no tier allocated; only tiers actually used become non-null
- [x] Deinit safety with mixed widths (Zig's debug allocator catches leaks)
- [x] Snapshot fixtures regenerated correctly (every `circuit.createComponent({s});` → `circuit.createComponent({s}, 1);` in emit output)

## Locked design decisions touched by this PR

From the S1 breakdown discussion:

- **Tier array shape** (locked Q2): `[MAX_WIDTH + 1]?Pool` fixed-size array with optional per slot. Lazy init via `getOrInitTier`. ~520 bytes of sentinel slots per Circuit; predictable dispatch.
- **`createComponent` width default** (locked Q3): Signature is `(kind, width)`; every existing call site updated mechanically to pass `1` explicitly. Zig has no parameter defaults, so "default to 1" is by convention rather than language feature.
- **Convention shift**: `tier = width` (tier 0 reserved/unused). Replaces the previous `tier 0 = width 1` mapping; two existing engine tests were updated to assert `tier == 1` accordingly.

## Three-commit structure

1. `2d50681` engine: replace Circuit.tier1 with lazy multi-tier Pool array  *(internal refactor; no API change; existing tests pass byte-identical except for tier number assertions)*
2. `5122377` engine: thread width through createComponent  *(public signature change + migration of 27 production callers across 6 files + emit template change + regen of 13 snapshot fixtures)*
3. `05ea9d1` engine: add multi-bit Circuit allocation tests  *(new coverage at widths 4, 8, 64 plus lazy-init and deinit safety)*

Out of scope for this PR (later sub-issues of #18):
- Gate evaluator rewrite + bench milestone (S1.4, #33, closes #18). The engine's `recalculateAndReschedule` still uses width-1 predicates; this PR only makes the multi-tier infrastructure available for the eventual rewrite.

Closes #32.