### PR TITLE
feat(topology): bump format to v02 with per-component width byte

### DIFF
--- a/lib/cli/inspect_dump.zig
+++ b/lib/cli/inspect_dump.zig
@@ -148,6 +148,7 @@ pub fn dumpIrModule(allocator: std.mem.Allocator, module: anytype) ![]u8 {
             try writer.writeAll("<none> kind=");
         }
         try dumpComponentKind(writer, component.kind);
+        try writer.writeAll(" width=1");
         try writer.writeByte('\n');
     }
 

--- a/lib/preview/dump.zig
+++ b/lib/preview/dump.zig
@@ -112,9 +112,9 @@ test "preview_dump_primitives" {
     defer buf.deinit(allocator);
 
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "a", .origin = &.{} },
-        .{ .id = 1, .kind = .input_pin, .name = "b", .origin = &.{} },
-        .{ .id = 2, .kind = .and_gate, .name = "g", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+        .{ .id = 1, .kind = .input_pin, .width = 1, .name = "b", .origin = &.{} },
+        .{ .id = 2, .kind = .and_gate, .width = 1, .name = "g", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 2, .port = @intFromEnum(full_format.PortName.a) },
@@ -151,9 +151,9 @@ test "preview_dump_with_origin" {
         .{ .alias = "g", .subcircuit = "xor", .target_file = 1 },
     };
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "a", .origin = &.{} },
-        .{ .id = 1, .kind = .not_gate, .name = "n1", .origin = &single_frame },
-        .{ .id = 2, .kind = .and_gate, .name = "a1", .origin = &single_frame },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+        .{ .id = 1, .kind = .not_gate, .width = 1, .name = "n1", .origin = &single_frame },
+        .{ .id = 2, .kind = .and_gate, .width = 1, .name = "a1", .origin = &single_frame },
     };
     const topo = FullTopology{ .components = &components, .connections = &.{} };
 
@@ -185,7 +185,7 @@ test "preview_dump_nested_origin" {
         .{ .alias = "", .subcircuit = "xor", .target_file = 1 },
     };
     const components = [_]FullComponentRecord{
-        .{ .id = 5, .kind = .not_gate, .name = "deep", .origin = &nested },
+        .{ .id = 5, .kind = .not_gate, .width = 1, .name = "deep", .origin = &nested },
     };
     const topo = FullTopology{ .components = &components, .connections = &.{} };
 
@@ -211,7 +211,7 @@ test "preview_dump_anonymous_component_name" {
     defer buf.deinit(allocator);
 
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .not_gate, .name = "", .origin = &.{} },
+        .{ .id = 0, .kind = .not_gate, .width = 1, .name = "", .origin = &.{} },
     };
     const topo = FullTopology{ .components = &components, .connections = &.{} };
 
@@ -227,9 +227,9 @@ test "preview_dump_port_decoding" {
     defer buf.deinit(allocator);
 
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "x", .origin = &.{} },
-        .{ .id = 1, .kind = .not_gate, .name = "n", .origin = &.{} },
-        .{ .id = 2, .kind = .and_gate, .name = "a", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "x", .origin = &.{} },
+        .{ .id = 1, .kind = .not_gate, .width = 1, .name = "n", .origin = &.{} },
+        .{ .id = 2, .kind = .and_gate, .width = 1, .name = "a", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 1, .port = @intFromEnum(full_format.PortName.in) },
@@ -249,8 +249,8 @@ test "preview_dump_deterministic_ordering" {
     const allocator = std.testing.allocator;
 
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "a", .origin = &.{} },
-        .{ .id = 1, .kind = .and_gate, .name = "g", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+        .{ .id = 1, .kind = .and_gate, .width = 1, .name = "g", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 1, .port = @intFromEnum(full_format.PortName.a) },

--- a/lib/preview/layout/collapse.zig
+++ b/lib/preview/layout/collapse.zig
@@ -289,9 +289,9 @@ test "collapse_drops_wire_primitives" {
 
     // pin → wire → led
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "p", .origin = &.{} },
-        .{ .id = 1, .kind = .wire, .name = "w", .origin = &.{} },
-        .{ .id = 2, .kind = .led, .name = "l", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "p", .origin = &.{} },
+        .{ .id = 1, .kind = .wire, .width = 1, .name = "w", .origin = &.{} },
+        .{ .id = 2, .kind = .led, .width = 1, .name = "l", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 1, .port = @intFromEnum(full_format.PortName.in) },
@@ -322,11 +322,11 @@ test "collapse_chains_of_wires" {
 
     // pin → wire → wire → wire → led
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "p", .origin = &.{} },
-        .{ .id = 1, .kind = .wire, .name = "w1", .origin = &.{} },
-        .{ .id = 2, .kind = .wire, .name = "w2", .origin = &.{} },
-        .{ .id = 3, .kind = .wire, .name = "w3", .origin = &.{} },
-        .{ .id = 4, .kind = .led, .name = "l", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "p", .origin = &.{} },
+        .{ .id = 1, .kind = .wire, .width = 1, .name = "w1", .origin = &.{} },
+        .{ .id = 2, .kind = .wire, .width = 1, .name = "w2", .origin = &.{} },
+        .{ .id = 3, .kind = .wire, .width = 1, .name = "w3", .origin = &.{} },
+        .{ .id = 4, .kind = .led, .width = 1, .name = "l", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 1, .port = @intFromEnum(full_format.PortName.in) },
@@ -359,10 +359,10 @@ test "collapse_opaque_subcircuit" {
         .{ .alias = "g", .subcircuit = "xor", .target_file = 1 },
     };
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "p", .origin = &.{} },
-        .{ .id = 1, .kind = .not_gate, .name = "n", .origin = &xor_origin },
-        .{ .id = 2, .kind = .and_gate, .name = "a", .origin = &xor_origin },
-        .{ .id = 3, .kind = .led, .name = "l", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "p", .origin = &.{} },
+        .{ .id = 1, .kind = .not_gate, .width = 1, .name = "n", .origin = &xor_origin },
+        .{ .id = 2, .kind = .and_gate, .width = 1, .name = "a", .origin = &xor_origin },
+        .{ .id = 3, .kind = .led, .width = 1, .name = "l", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 1, .port = @intFromEnum(full_format.PortName.in) },
@@ -410,10 +410,10 @@ test "collapse_expanded_subcircuit" {
         .{ .alias = "g", .subcircuit = "xor", .target_file = 1 },
     };
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "p", .origin = &.{} },
-        .{ .id = 1, .kind = .not_gate, .name = "n", .origin = &xor_origin },
-        .{ .id = 2, .kind = .and_gate, .name = "a", .origin = &xor_origin },
-        .{ .id = 3, .kind = .led, .name = "l", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "p", .origin = &.{} },
+        .{ .id = 1, .kind = .not_gate, .width = 1, .name = "n", .origin = &xor_origin },
+        .{ .id = 2, .kind = .and_gate, .width = 1, .name = "a", .origin = &xor_origin },
+        .{ .id = 3, .kind = .led, .width = 1, .name = "l", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 1, .port = @intFromEnum(full_format.PortName.in) },

--- a/lib/topology/format.zig
+++ b/lib/topology/format.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
 pub const MAGIC: [4]u8 = .{ 'C', 'I', 'R', 'C' };
-pub const VERSION: u8 = 0x01;
+pub const VERSION: u8 = 0x02;
 
 pub const ComponentKind = enum(u8) {
     input_pin = 0,
@@ -22,6 +22,7 @@ pub const PortName = enum(u8) {
 pub const ComponentRecord = extern struct {
     id: u32,
     kind: u8,
+    width: u8,
 };
 
 pub const ConnectionRecord = extern struct {

--- a/lib/topology/full_decoder.zig
+++ b/lib/topology/full_decoder.zig
@@ -71,6 +71,7 @@ pub fn decode(allocator: std.mem.Allocator, bytes: []const u8) !FullTopology {
         const id = try cursor.readU32LE();
         const kind_byte = try cursor.readU8();
         const kind = std.meta.intToEnum(ComponentKind, kind_byte) catch return error.UnknownComponentKind;
+        const width = try cursor.readU8();
         const name = try dupString(allocator, &cursor);
         errdefer allocator.free(name);
 
@@ -94,7 +95,7 @@ pub fn decode(allocator: std.mem.Allocator, bytes: []const u8) !FullTopology {
             origin_built += 1;
         }
 
-        comp.* = .{ .id = id, .kind = kind, .name = name, .origin = origin };
+        comp.* = .{ .id = id, .kind = kind, .width = width, .name = name, .origin = origin };
         components_built += 1;
     }
 
@@ -128,7 +129,7 @@ test "full_decode: empty payload round-trips" {
     const allocator = std.testing.allocator;
     const bytes = [_]u8{
         'C', 'I', 'R', 'F',
-        0x01,
+        0x02,
         0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00,
     };
@@ -139,8 +140,14 @@ test "full_decode: empty payload round-trips" {
     try std.testing.expectEqual(@as(usize, 0), topo.connections.len);
 }
 
+test "full_decode_rejects_v01" {
+    const allocator = std.testing.allocator;
+    const bytes = [_]u8{ 'C', 'I', 'R', 'F', 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try std.testing.expectError(error.UnsupportedVersion, decode(allocator, &bytes));
+}
+
 test "full_decode_rejects_truncated_input" {
     const allocator = std.testing.allocator;
-    const truncated = [_]u8{ 'C', 'I', 'R', 'F', 0x01 };
+    const truncated = [_]u8{ 'C', 'I', 'R', 'F', 0x02 };
     try std.testing.expectError(error.Truncated, decode(allocator, &truncated));
 }

--- a/lib/topology/full_format.zig
+++ b/lib/topology/full_format.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const format = @import("format");
 
 pub const FULL_MAGIC: [4]u8 = .{ 'C', 'I', 'R', 'F' };
-pub const FULL_VERSION: u8 = 0x01;
+pub const FULL_VERSION: u8 = 0x02;
 
 pub const ComponentKind = format.ComponentKind;
 pub const PortName = format.PortName;
@@ -17,6 +17,7 @@ pub const OriginFrame = struct {
 pub const FullComponentRecord = struct {
     id: u32,
     kind: ComponentKind,
+    width: u8,
     name: []const u8,
     origin: []const OriginFrame,
 };
@@ -41,7 +42,7 @@ pub const FullTopology = struct {
 
 test "full_format: magic and version are stable" {
     try std.testing.expectEqualSlices(u8, "CIRF", &FULL_MAGIC);
-    try std.testing.expectEqual(@as(u8, 0x01), FULL_VERSION);
+    try std.testing.expectEqual(@as(u8, 0x02), FULL_VERSION);
 }
 
 test "full_format: kind values mirror min payload" {

--- a/lib/topology/full_serializer.zig
+++ b/lib/topology/full_serializer.zig
@@ -30,6 +30,7 @@ pub fn encode(allocator: std.mem.Allocator, topology: FullTopology) ![]u8 {
     for (topology.components) |comp| {
         try appendU32LE(&out, allocator, comp.id);
         try out.append(allocator, @intFromEnum(comp.kind));
+        try out.append(allocator, comp.width);
         try appendString(&out, allocator, comp.name);
         try appendU32LE(&out, allocator, @intCast(comp.origin.len));
         for (comp.origin) |frame| {
@@ -179,6 +180,7 @@ fn expandModule(
                 try state.components.append(state.allocator, .{
                     .id = global_id,
                     .kind = primitiveToKind(p),
+                    .width = 1,
                     .name = name_copy,
                     .origin = origin_copy,
                 });
@@ -318,6 +320,7 @@ pub fn buildFromModule(allocator: std.mem.Allocator, module: *const ir.Module) !
                 try components.append(allocator, .{
                     .id = comp.id.value,
                     .kind = primitiveToKind(p),
+                    .width = 1,
                     .name = name_copy,
                     .origin = empty_origin,
                 });
@@ -359,7 +362,7 @@ test "full_encode_empty: locks the wire format" {
     // magic(4) + version(1) + num_components(4) + num_connections(4) = 13 bytes
     const expected = [_]u8{
         'C', 'I', 'R', 'F',
-        0x01,
+        0x02,
         0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00,
     };
@@ -369,31 +372,33 @@ test "full_encode_empty: locks the wire format" {
 test "full_encode: single component with no origin emits expected layout" {
     const allocator = std.testing.allocator;
     const components = [_]FullComponentRecord{
-        .{ .id = 7, .kind = .not_gate, .name = "n1", .origin = &.{} },
+        .{ .id = 7, .kind = .not_gate, .width = 1, .name = "n1", .origin = &.{} },
     };
     const topo = FullTopology{ .components = &components, .connections = &.{} };
 
     const bytes = try encode(allocator, topo);
     defer allocator.free(bytes);
 
-    // magic(4)+ver(1)+num_components(4) + id(4)+kind(1)+name_len(4)+name(2)+origin_len(4) + num_connections(4) = 28
-    try std.testing.expectEqual(@as(usize, 28), bytes.len);
+    // magic(4)+ver(1)+num_components(4) + id(4)+kind(1)+width(1)+name_len(4)+name(2)+origin_len(4) + num_connections(4) = 29
+    try std.testing.expectEqual(@as(usize, 29), bytes.len);
     try std.testing.expectEqualSlices(u8, "CIRF", bytes[0..4]);
-    try std.testing.expectEqual(@as(u8, 0x01), bytes[4]);
+    try std.testing.expectEqual(@as(u8, 0x02), bytes[4]);
     // num_components = 1
     try std.testing.expectEqual(@as(u32, 1), std.mem.readInt(u32, bytes[5..9], .little));
     // id = 7
     try std.testing.expectEqual(@as(u32, 7), std.mem.readInt(u32, bytes[9..13], .little));
     // kind = not_gate
     try std.testing.expectEqual(@intFromEnum(full_format.ComponentKind.not_gate), bytes[13]);
+    // width = 1
+    try std.testing.expectEqual(@as(u8, 1), bytes[14]);
     // name_len = 2
-    try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, bytes[14..18], .little));
+    try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, bytes[15..19], .little));
     // name = "n1"
-    try std.testing.expectEqualSlices(u8, "n1", bytes[18..20]);
+    try std.testing.expectEqualSlices(u8, "n1", bytes[19..21]);
     // origin_len = 0
-    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, bytes[20..24], .little));
+    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, bytes[21..25], .little));
     // num_connections = 0
-    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, bytes[24..28], .little));
+    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, bytes[25..29], .little));
 }
 
 // ---------- IR-walk tests (slice 4) ----------

--- a/lib/topology/serializer.zig
+++ b/lib/topology/serializer.zig
@@ -26,6 +26,7 @@ pub fn serializeModule(
         try components.append(allocator, .{
             .id = comp.id.value,
             .kind = @intFromEnum(kind),
+            .width = 1,
         });
     }
 
@@ -167,6 +168,7 @@ fn expandModule(
                 try state.components.append(state.allocator, .{
                     .id = global_id,
                     .kind = @intFromEnum(kind),
+                    .width = 1,
                 });
             },
             .sub_circuit_ref => |ref| {
@@ -309,6 +311,7 @@ fn encodePayload(
         std.mem.writeInt(u32, &buf, comp.id, .little);
         try out.appendSlice(allocator, &buf);
         try out.append(allocator, comp.kind);
+        try out.append(allocator, comp.width);
     }
 
     for (connections) |connection| {
@@ -365,20 +368,23 @@ test "serialize: inverter module bytes" {
     // conn_count = 2
     try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, payload[9..13][0..4], .little));
     
-    // Verify records
+    // Verify records (each: id(4)+kind(1)+width(1) = 6 bytes)
     var offset: usize = 13;
     // Comp 0
     try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, payload[offset..offset+4][0..4], .little));
     try std.testing.expectEqual(@intFromEnum(format.ComponentKind.input_pin), payload[offset+4]);
-    offset += 5;
+    try std.testing.expectEqual(@as(u8, 1), payload[offset+5]);
+    offset += 6;
     // Comp 1
     try std.testing.expectEqual(@as(u32, 1), std.mem.readInt(u32, payload[offset..offset+4][0..4], .little));
     try std.testing.expectEqual(@intFromEnum(format.ComponentKind.not_gate), payload[offset+4]);
-    offset += 5;
+    try std.testing.expectEqual(@as(u8, 1), payload[offset+5]);
+    offset += 6;
     // Comp 2
     try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, payload[offset..offset+4][0..4], .little));
     try std.testing.expectEqual(@intFromEnum(format.ComponentKind.output_pin), payload[offset+4]);
-    offset += 5;
+    try std.testing.expectEqual(@as(u8, 1), payload[offset+5]);
+    offset += 6;
     
     // Conn 0
     try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, payload[offset..offset+4][0..4], .little));
@@ -413,6 +419,26 @@ test "serialize: unknown port name returns error" {
     };
     
     try std.testing.expectError(error.UnknownPortName, serializeModule(allocator, &module));
+}
+
+test "serialize: width round-trip at 1, 4, 8" {
+    // Construct ComponentRecord values directly at the topology layer (S2 scope:
+    // the IR doesn't carry width yet; S4 lands the producer side). This checks
+    // that encodePayload preserves the width byte for arbitrary u8 values.
+    const allocator = std.testing.allocator;
+    const widths = [_]u8{ 1, 4, 8 };
+    for (widths) |w| {
+        const components = [_]format.ComponentRecord{
+            .{ .id = 0, .kind = @intFromEnum(format.ComponentKind.and_gate), .width = w },
+        };
+        const payload = try encodePayload(allocator, &components, &.{});
+        defer allocator.free(payload);
+
+        try std.testing.expectEqual(format.VERSION, payload[4]);
+        // Layout: magic(4)+ver(1)+comp_count(4)+conn_count(4) = 13, then id(4)+kind(1)+width(1).
+        try std.testing.expectEqual(@intFromEnum(format.ComponentKind.and_gate), payload[13 + 4]);
+        try std.testing.expectEqual(w, payload[13 + 5]);
+    }
 }
 
 test "serialize: half-adder project flat" {

--- a/lib/truth_table/builder.zig
+++ b/lib/truth_table/builder.zig
@@ -187,10 +187,10 @@ fn topo(components: []const FullComponentRecord, connections: []const FullConnec
 test "truth_table_build_and_two_inputs" {
     // a (id=0, input_pin) → and.a, b (id=1, input_pin) → and.b, and(id=2) → out(id=3, output_pin)
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "a", .origin = &.{} },
-        .{ .id = 1, .kind = .input_pin, .name = "b", .origin = &.{} },
-        .{ .id = 2, .kind = .and_gate, .name = "g", .origin = &.{} },
-        .{ .id = 3, .kind = .output_pin, .name = "result", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+        .{ .id = 1, .kind = .input_pin, .width = 1, .name = "b", .origin = &.{} },
+        .{ .id = 2, .kind = .and_gate, .width = 1, .name = "g", .origin = &.{} },
+        .{ .id = 3, .kind = .output_pin, .width = 1, .name = "result", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 2, .port = @intFromEnum(full_format.PortName.a) },
@@ -221,9 +221,9 @@ test "truth_table_build_and_two_inputs" {
 test "truth_table_build_not_gate" {
     // Single-input NOT: input(0) → not(1) → output_pin(2)
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "in", .origin = &.{} },
-        .{ .id = 1, .kind = .not_gate, .name = "n", .origin = &.{} },
-        .{ .id = 2, .kind = .output_pin, .name = "out", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "in", .origin = &.{} },
+        .{ .id = 1, .kind = .not_gate, .width = 1, .name = "n", .origin = &.{} },
+        .{ .id = 2, .kind = .output_pin, .width = 1, .name = "out", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 1, .port = @intFromEnum(full_format.PortName.in) },
@@ -242,11 +242,11 @@ test "truth_table_build_rejects_too_many_inputs" {
     // 17 input pins exceeds the default 16 cap.
     var components: [17]FullComponentRecord = undefined;
     inline for (0..17) |idx| {
-        components[idx] = .{ .id = idx, .kind = .input_pin, .name = "x", .origin = &.{} };
+        components[idx] = .{ .id = idx, .kind = .input_pin, .width = 1, .name = "x", .origin = &.{} };
     }
     // Need at least one output so we don't hit NoOutputs first.
     const all_components = components ++ [_]FullComponentRecord{
-        .{ .id = 17, .kind = .output_pin, .name = "out", .origin = &.{} },
+        .{ .id = 17, .kind = .output_pin, .width = 1, .name = "out", .origin = &.{} },
     };
     const t = topo(&all_components, &.{});
     try std.testing.expectError(error.TooManyInputs, build(test_alloc, t, .{}));
@@ -255,7 +255,7 @@ test "truth_table_build_rejects_too_many_inputs" {
 test "truth_table_build_rejects_no_outputs" {
     // Inputs only, no outputs.
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "a", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
     };
     const t = topo(&components, &.{});
     try std.testing.expectError(error.NoOutputs, build(test_alloc, t, .{}));
@@ -265,8 +265,8 @@ test "truth_table_build_undefined_for_unconnected_output" {
     // input(0), output(1) but no connection between them. The output_pin has
     // no driver, so its state stays .undefined for every input vector.
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "a", .origin = &.{} },
-        .{ .id = 1, .kind = .output_pin, .name = "out", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+        .{ .id = 1, .kind = .output_pin, .width = 1, .name = "out", .origin = &.{} },
     };
     const t = topo(&components, &.{});
     var table = try build(test_alloc, t, .{});

--- a/templates/interpreter.zig
+++ b/templates/interpreter.zig
@@ -28,7 +28,7 @@ pub fn initFromTopology(circuit: *engine.Circuit, payload: []const u8) !void {
     const comp_count = readU32(payload[5..9][0..4]);
     const conn_count = readU32(payload[9..13][0..4]);
 
-    const comp_bytes = 5 * comp_count;
+    const comp_bytes = 6 * comp_count;
     const conn_bytes = 9 * conn_count;
 
     if (payload.len < 13 + comp_bytes + conn_bytes) return error.TruncatedPayload;
@@ -41,18 +41,19 @@ pub fn initFromTopology(circuit: *engine.Circuit, payload: []const u8) !void {
     for (0..comp_count) |_| {
         const id = readU32(payload[offset .. offset + 4][0..4]);
         const kind_val = payload[offset + 4];
-        offset += 5;
+        const width = payload[offset + 5];
+        offset += 6;
 
         const component_kind = std.meta.intToEnum(format.ComponentKind, kind_val) catch return error.InvalidComponentKind;
         const comp = switch (component_kind) {
-            .input_pin => try circuit.createComponent(.{ .input_pin_gate = .{} }, 1),
-            .not_gate => try circuit.createComponent(.{ .not_gate = .{} }, 1),
-            .and_gate => try circuit.createComponent(.{ .and_gate = .{} }, 1),
-            .wire => try circuit.createComponent(.{ .wire = .{} }, 1),
-            .led => try circuit.createComponent(.{ .led = .{} }, 1),
-            .output_pin => try circuit.createComponent(.{ .output_pin = .{} }, 1),
+            .input_pin => try circuit.createComponent(.{ .input_pin_gate = .{} }, width),
+            .not_gate => try circuit.createComponent(.{ .not_gate = .{} }, width),
+            .and_gate => try circuit.createComponent(.{ .and_gate = .{} }, width),
+            .wire => try circuit.createComponent(.{ .wire = .{} }, width),
+            .led => try circuit.createComponent(.{ .led = .{} }, width),
+            .output_pin => try circuit.createComponent(.{ .output_pin = .{} }, width),
         };
-        comp.id = id; 
+        comp.id = id;
         comp_map.putAssumeCapacity(id, comp);
     }
 
@@ -89,7 +90,16 @@ test "interpreter: rejects unknown version" {
     defer circuit.deinit();
     var payload = [_]u8{0} ** 13;
     std.mem.copyForwards(u8, payload[0..4], &format.MAGIC);
-    payload[4] = 0x02; 
+    payload[4] = 0x99;
+    try std.testing.expectError(error.UnsupportedVersion, initFromTopology(&circuit, &payload));
+}
+
+test "interpreter: rejects v01 payload" {
+    var circuit = try engine.Circuit.init();
+    defer circuit.deinit();
+    var payload = [_]u8{0} ** 13;
+    std.mem.copyForwards(u8, payload[0..4], &format.MAGIC);
+    payload[4] = 0x01;
     try std.testing.expectError(error.UnsupportedVersion, initFromTopology(&circuit, &payload));
 }
 
@@ -108,9 +118,11 @@ test "interpreter: single not-gate topology" {
     
     try payload.appendSlice(allocator, &[_]u8{0, 0, 0, 0});
     try payload.append(allocator, @intFromEnum(format.ComponentKind.wire));
-    
+    try payload.append(allocator, 1);
+
     try payload.appendSlice(allocator, &[_]u8{1, 0, 0, 0});
     try payload.append(allocator, @intFromEnum(format.ComponentKind.not_gate));
+    try payload.append(allocator, 1);
     
     try payload.appendSlice(allocator, &[_]u8{0, 0, 0, 0}); 
     try payload.appendSlice(allocator, &[_]u8{1, 0, 0, 0}); 

--- a/tests/e2e/topology_protocol_test.zig
+++ b/tests/e2e/topology_protocol_test.zig
@@ -50,13 +50,15 @@ test "topology host protocol: inverter round-trip via Node" {
     try topo.appendSlice(allocator, &[_]u8{2, 0, 0, 0}); // comp_count = 2
     try topo.appendSlice(allocator, &[_]u8{1, 0, 0, 0}); // conn_count = 1
     
-    // Component 0: input_pin
+    // Component 0: input_pin (width=1)
     try topo.appendSlice(allocator, &[_]u8{0, 0, 0, 0});
     try topo.append(allocator, @intFromEnum(format.ComponentKind.input_pin));
-    
-    // Component 1: not_gate
+    try topo.append(allocator, 1);
+
+    // Component 1: not_gate (width=1)
     try topo.appendSlice(allocator, &[_]u8{1, 0, 0, 0});
     try topo.append(allocator, @intFromEnum(format.ComponentKind.not_gate));
+    try topo.append(allocator, 1);
     
     // Connection: from 0, to 1, port "in"
     try topo.appendSlice(allocator, &[_]u8{0, 0, 0, 0});

--- a/tests/fixtures/expected-inspect/canonical_full_adder_root.txt
+++ b/tests/fixtures/expected-inspect/canonical_full_adder_root.txt
@@ -39,14 +39,14 @@ Outputs (2)
   id=0 name=sum driver=4.sum
   id=1 name=cout driver=5.out
 Components (8)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=b kind=primitive:input_pin
-  id=2 name=cin kind=primitive:input_pin
-  id=3 name=ha1 kind=sub_circuit_ref:half_adder
-  id=4 name=ha2 kind=sub_circuit_ref:half_adder
-  id=5 name=cout_or kind=unresolved_name:or
-  id=6 name=sum kind=primitive:output_pin
-  id=7 name=cout kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=b kind=primitive:input_pin width=1
+  id=2 name=cin kind=primitive:input_pin width=1
+  id=3 name=ha1 kind=sub_circuit_ref:half_adder width=1
+  id=4 name=ha2 kind=sub_circuit_ref:half_adder width=1
+  id=5 name=cout_or kind=unresolved_name:or width=1
+  id=6 name=sum kind=primitive:output_pin width=1
+  id=7 name=cout kind=primitive:output_pin width=1
 Connections (8)
   0.out -> 3.a
   1.out -> 3.b

--- a/tests/fixtures/expected-inspect/canonical_half_adder_root.txt
+++ b/tests/fixtures/expected-inspect/canonical_half_adder_root.txt
@@ -28,11 +28,11 @@ Outputs (2)
   id=0 name=sum driver=2.sum
   id=1 name=carry driver=2.carry
 Components (5)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=b kind=primitive:input_pin
-  id=2 name=ha kind=sub_circuit_ref:half_adder
-  id=3 name=sum kind=primitive:output_pin
-  id=4 name=carry kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=b kind=primitive:input_pin width=1
+  id=2 name=ha kind=sub_circuit_ref:half_adder width=1
+  id=3 name=sum kind=primitive:output_pin width=1
+  id=4 name=carry kind=primitive:output_pin width=1
 Connections (4)
   0.out -> 2.a
   1.out -> 2.b

--- a/tests/fixtures/expected-inspect/clean_inverter.txt
+++ b/tests/fixtures/expected-inspect/clean_inverter.txt
@@ -20,9 +20,9 @@ Inputs (1)
 Outputs (1)
   id=0 name=out driver=1.out
 Components (3)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=inv kind=primitive:not_gate
-  id=2 name=out kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=inv kind=primitive:not_gate width=1
+  id=2 name=out kind=primitive:output_pin width=1
 Connections (2)
   0.out -> 1.in
   1.out -> 2.in

--- a/tests/fixtures/expected-inspect/error_undeclared.txt
+++ b/tests/fixtures/expected-inspect/error_undeclared.txt
@@ -20,9 +20,9 @@ Inputs (1)
 Outputs (1)
   id=0 name=out driver=1.out
 Components (3)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=u1 kind=unresolved_name:mystery
-  id=2 name=out kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=u1 kind=unresolved_name:mystery width=1
+  id=2 name=out kind=primitive:output_pin width=1
 Connections (2)
   0.out -> 1.in
   1.out -> 2.in

--- a/tests/topology/full_emit_integration_test.zig
+++ b/tests/topology/full_emit_integration_test.zig
@@ -141,8 +141,8 @@ test "phase0_full_pipeline_roundtrip: and_pair fixture carries both sections wit
     try std.testing.expectEqual(@as(usize, min_conn_count), decoded.connections.len);
 
     // Walk min bytes to extract each connection record and compare with decoded full.
-    // Min layout: header(13) + components(5 bytes each) + connections(9 bytes each).
-    var min_pos: usize = 13 + min_component_count * 5;
+    // Min layout: header(13) + components(6 bytes each: id+kind+width) + connections(9 bytes each).
+    var min_pos: usize = 13 + min_component_count * 6;
     for (decoded.connections) |full_conn| {
         const from_id = std.mem.readInt(u32, min_bytes[min_pos..][0..4], .little);
         min_pos += 4;

--- a/tests/topology/full_roundtrip_test.zig
+++ b/tests/topology/full_roundtrip_test.zig
@@ -11,6 +11,7 @@ const OriginFrame = full_format.OriginFrame;
 fn expectComponentEqual(expected: FullComponentRecord, actual: FullComponentRecord) !void {
     try std.testing.expectEqual(expected.id, actual.id);
     try std.testing.expectEqual(expected.kind, actual.kind);
+    try std.testing.expectEqual(expected.width, actual.width);
     try std.testing.expectEqualStrings(expected.name, actual.name);
     try std.testing.expectEqual(expected.origin.len, actual.origin.len);
     for (expected.origin, actual.origin) |exp_frame, act_frame| {
@@ -24,9 +25,9 @@ test "full_encode_decode_roundtrip_simple" {
     const allocator = std.testing.allocator;
 
     const components = [_]FullComponentRecord{
-        .{ .id = 0, .kind = .input_pin, .name = "a", .origin = &.{} },
-        .{ .id = 1, .kind = .input_pin, .name = "b", .origin = &.{} },
-        .{ .id = 2, .kind = .and_gate, .name = "g1", .origin = &.{} },
+        .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+        .{ .id = 1, .kind = .input_pin, .width = 1, .name = "b", .origin = &.{} },
+        .{ .id = 2, .kind = .and_gate, .width = 1, .name = "g1", .origin = &.{} },
     };
     const connections = [_]FullConnectionRecord{
         .{ .from_id = 0, .to_id = 2, .port = @intFromEnum(full_format.PortName.a) },
@@ -62,9 +63,9 @@ test "full_encode_decode_roundtrip_with_origin" {
     };
 
     const components = [_]FullComponentRecord{
-        .{ .id = 10, .kind = .not_gate, .name = "n_in_combine", .origin = &single_frame },
-        .{ .id = 11, .kind = .and_gate, .name = "a_in_combine", .origin = &single_frame },
-        .{ .id = 12, .kind = .not_gate, .name = "n_in_nested", .origin = &nested_frames },
+        .{ .id = 10, .kind = .not_gate, .width = 1, .name = "n_in_combine", .origin = &single_frame },
+        .{ .id = 11, .kind = .and_gate, .width = 1, .name = "a_in_combine", .origin = &single_frame },
+        .{ .id = 12, .kind = .not_gate, .width = 1, .name = "n_in_nested", .origin = &nested_frames },
     };
     const original = FullTopology{ .components = &components, .connections = &.{} };
 
@@ -82,4 +83,28 @@ test "full_encode_decode_roundtrip_with_origin" {
     try std.testing.expectEqualStrings("", decoded.components[2].origin[1].alias);
     try std.testing.expectEqualStrings("xor", decoded.components[2].origin[1].subcircuit);
     try std.testing.expectEqual(@as(u32, 7), decoded.components[2].origin[1].target_file);
+}
+
+test "full_encode_decode_roundtrip_widths_1_4_8" {
+    // S2 reserves the width byte. The IR doesn't carry width yet (S4), so this
+    // constructs FullComponentRecord values directly at the topology layer and
+    // verifies the width survives encode → decode unchanged.
+    const allocator = std.testing.allocator;
+    const widths = [_]u8{ 1, 4, 8 };
+    for (widths) |w| {
+        const components = [_]FullComponentRecord{
+            .{ .id = 0, .kind = .input_pin, .width = w, .name = "a", .origin = &.{} },
+            .{ .id = 1, .kind = .and_gate, .width = w, .name = "g", .origin = &.{} },
+        };
+        const original = FullTopology{ .components = &components, .connections = &.{} };
+
+        const bytes = try full_serializer.encode(allocator, original);
+        defer allocator.free(bytes);
+
+        var decoded = try full_decoder.decode(allocator, bytes);
+        defer decoded.deinit(allocator);
+
+        try std.testing.expectEqual(@as(usize, 2), decoded.components.len);
+        for (components, decoded.components) |exp, act| try expectComponentEqual(exp, act);
+    }
 }


### PR DESCRIPTION
Bumps the `circ.topology.v0.min` and `circ.topology.v0.full` payloads from version `0x01` to `0x02`, adding a `width: u8` byte to every component record. This reserves the slot the IR will populate in a later stage; producers in this PR emit `width = 1` for every component.

## What changed

- `lib/topology/format.zig`, `lib/topology/full_format.zig`: bump `VERSION` / `FULL_VERSION` to `0x02`. `ComponentRecord` and `FullComponentRecord` grow `width: u8`.
- `lib/topology/serializer.zig`, `full_serializer.zig`: emit the new byte (always `1` — IR doesn't carry width yet).
- `lib/topology/full_decoder.zig`: reads the new byte; `0x01` payloads now produce `error.UnsupportedVersion`.
- `templates/interpreter.zig`: per-component stride goes from 5 → 6 bytes. The runtime reads the width byte and forwards it to `circuit.createComponent` instead of the hard-coded `1`.
- `lib/cli/inspect_dump.zig`: IR dump prints a `width=1` column on every component line. Expected-inspect fixtures regenerated.
- Test fixtures across `lib/preview`, `lib/truth_table`, and `lib/topology` were updated to construct the grown record literals.

## Acceptance

- Round-trip tests at widths 1, 4, 8 (`tests/topology/full_roundtrip_test.zig`, `lib/topology/serializer.zig`) construct records directly at the topology layer and verify the width survives encode → decode.
- Decoders reject `0x01` payloads with `error.UnsupportedVersion` (`full_decoder.zig`, `templates/interpreter.zig`).
- All existing expected-inspect goldens regenerate with the new column.
- `zig build test`: 320/320 pass. A compiled `.wasm` from `tests/fixtures/circuits/inverter.circ` loads and exercises a width=1 circuit through the behavioral harness.

## Notes

- No backward-compat shim: the format is internal to a compiled artifact and the only consumer is `circ-compile` itself.
- Width round-trip tests at widths 4 and 8 build `ComponentRecord` / `FullComponentRecord` values directly because the IR cannot produce them yet; populating width from the IR lands in a later stage.

Closes #19. Plan context: `DOCS/plan-multi-bit-language.md` (Stage 2).