### PR TITLE
feat(ir): thread literal widths from AST through resolver and topology

### DIFF
--- a/lib/ir/resolver.zig
+++ b/lib/ir/resolver.zig
@@ -31,6 +31,14 @@ fn toIrSpan(span: anytype) ir.Span {
     };
 }
 
+fn widthFromSpec(spec: ?ast.WidthSpec) !u8 {
+    const w = spec orelse return 1;
+    return switch (w) {
+        .literal => |n| n,
+        .parameter => error.ParametricWidthNotImplemented,
+    };
+}
+
 fn isPrimitive(name: []const u8) ?ir.PrimitiveKind {
     if (std.mem.eql(u8, name, "and")) return .and_gate;
     if (std.mem.eql(u8, name, "not")) return .not_gate;
@@ -78,11 +86,14 @@ fn addComponent(
     else
         ir.ComponentKind{ .unresolved_name = component_ast.type_name.text };
 
+    const width = try widthFromSpec(component_ast.type_name.width);
+
     try ctx.components.append(ctx.allocator, .{
         .id = id,
         .kind = kind,
         .instance_name = if (component_ast.instance_name) |name| name.text else null,
         .span = toIrSpan(component_ast.span),
+        .width = width,
     });
 
     if (component_ast.instance_name) |name| {
@@ -163,12 +174,14 @@ pub fn resolve(allocator: std.mem.Allocator, file: ast.File, file_id: u32) anyer
 
     for (file.inputs) |input_decl| {
         for (input_decl.names) |name| {
+            const width = try widthFromSpec(name.width);
             const component_id = nextComponentId(&ctx);
             try ctx.components.append(allocator, .{
                 .id = component_id,
                 .kind = .{ .primitive = .input_pin },
                 .instance_name = name.text,
                 .span = toIrSpan(input_decl.span),
+                .width = width,
             });
             try ctx.name_to_component.put(name.text, component_id);
             try ctx.input_pins.append(allocator, .{
@@ -176,6 +189,7 @@ pub fn resolve(allocator: std.mem.Allocator, file: ast.File, file_id: u32) anyer
                 .name = name.text,
                 .component = component_id,
                 .span = toIrSpan(name.span),
+                .width = width,
             });
         }
     }
@@ -187,12 +201,14 @@ pub fn resolve(allocator: std.mem.Allocator, file: ast.File, file_id: u32) anyer
     try resolvePendingPorts(&ctx);
 
     for (file.outputs) |output_decl| {
+        const width = try widthFromSpec(output_decl.name.width);
         const output_component_id = nextComponentId(&ctx);
         try ctx.components.append(allocator, .{
             .id = output_component_id,
             .kind = .{ .primitive = .output_pin },
             .instance_name = output_decl.name.text,
             .span = toIrSpan(output_decl.span),
+            .width = width,
         });
         try ctx.name_to_component.put(output_decl.name.text, output_component_id);
 
@@ -202,6 +218,7 @@ pub fn resolve(allocator: std.mem.Allocator, file: ast.File, file_id: u32) anyer
             .name = output_decl.name.text,
             .driver = driver,
             .span = toIrSpan(output_decl.span),
+            .width = width,
         });
         if (!isValidEndpoint(driver)) continue;
         try ctx.connections.append(allocator, .{

--- a/lib/ir/types.zig
+++ b/lib/ir/types.zig
@@ -39,6 +39,7 @@ pub const Component = struct {
     kind: ComponentKind,
     instance_name: ?[]const u8,
     span: Span,
+    width: u8 = 1,
 };
 
 pub const SignalEndpoint = struct {
@@ -62,6 +63,7 @@ pub const InputPin = struct {
     name: []const u8,
     component: ComponentId,
     span: Span,
+    width: u8 = 1,
 };
 
 pub const OutputPin = struct {
@@ -69,6 +71,7 @@ pub const OutputPin = struct {
     name: []const u8,
     driver: SignalEndpoint,
     span: Span,
+    width: u8 = 1,
 };
 
 pub const UnresolvedImport = struct {

--- a/lib/topology/full_serializer.zig
+++ b/lib/topology/full_serializer.zig
@@ -180,7 +180,7 @@ fn expandModule(
                 try state.components.append(state.allocator, .{
                     .id = global_id,
                     .kind = primitiveToKind(p),
-                    .width = 1,
+                    .width = comp.width,
                     .name = name_copy,
                     .origin = origin_copy,
                 });
@@ -320,7 +320,7 @@ pub fn buildFromModule(allocator: std.mem.Allocator, module: *const ir.Module) !
                 try components.append(allocator, .{
                     .id = comp.id.value,
                     .kind = primitiveToKind(p),
-                    .width = 1,
+                    .width = comp.width,
                     .name = name_copy,
                     .origin = empty_origin,
                 });

--- a/lib/topology/serializer.zig
+++ b/lib/topology/serializer.zig
@@ -26,7 +26,7 @@ pub fn serializeModule(
         try components.append(allocator, .{
             .id = comp.id.value,
             .kind = @intFromEnum(kind),
-            .width = 1,
+            .width = comp.width,
         });
     }
 
@@ -168,7 +168,7 @@ fn expandModule(
                 try state.components.append(state.allocator, .{
                     .id = global_id,
                     .kind = @intFromEnum(kind),
-                    .width = 1,
+                    .width = comp.width,
                 });
             },
             .sub_circuit_ref => |ref| {
@@ -422,9 +422,6 @@ test "serialize: unknown port name returns error" {
 }
 
 test "serialize: width round-trip at 1, 4, 8" {
-    // Construct ComponentRecord values directly at the topology layer (S2 scope:
-    // the IR doesn't carry width yet; S4 lands the producer side). This checks
-    // that encodePayload preserves the width byte for arbitrary u8 values.
     const allocator = std.testing.allocator;
     const widths = [_]u8{ 1, 4, 8 };
     for (widths) |w| {
@@ -438,6 +435,35 @@ test "serialize: width round-trip at 1, 4, 8" {
         // Layout: magic(4)+ver(1)+comp_count(4)+conn_count(4) = 13, then id(4)+kind(1)+width(1).
         try std.testing.expectEqual(@intFromEnum(format.ComponentKind.and_gate), payload[13 + 4]);
         try std.testing.expectEqual(w, payload[13 + 5]);
+    }
+}
+
+test "serialize: ir.Component.width threads into payload width byte" {
+    const allocator = std.testing.allocator;
+    const span = ir.Span{ .file_id = 0, .start_line = 0, .start_col = 0, .end_line = 0, .end_col = 0 };
+
+    const components = [_]ir.Component{
+        .{ .id = .{ .value = 0 }, .kind = .{ .primitive = .input_pin }, .instance_name = "a", .span = span, .width = 4 },
+        .{ .id = .{ .value = 1 }, .kind = .{ .primitive = .and_gate }, .instance_name = "g", .span = span, .width = 4 },
+        .{ .id = .{ .value = 2 }, .kind = .{ .primitive = .output_pin }, .instance_name = "r", .span = span, .width = 4 },
+    };
+    const module = ir.Module{
+        .file_id = .{ .value = 0 },
+        .inputs = &.{},
+        .outputs = &.{},
+        .components = &components,
+        .connections = &.{},
+        .imports = &.{},
+    };
+
+    const payload = try serializeModule(allocator, &module);
+    defer allocator.free(payload);
+
+    // Header is magic(4)+ver(1)+comp_count(4)+conn_count(4) = 13. Each record is id(4)+kind(1)+width(1) = 6.
+    var offset: usize = 13;
+    for (components) |_| {
+        try std.testing.expectEqual(@as(u8, 4), payload[offset + 5]);
+        offset += 6;
     }
 }
 

--- a/tests/fixtures/circuits/multibit_and_full.circ
+++ b/tests/fixtures/circuits/multibit_and_full.circ
@@ -1,0 +1,3 @@
+input[4] a, b
+and[4] g(a=a, b=b)
+output[4] r(in=g.out)

--- a/tests/fixtures/circuits/multibit_led_full.circ
+++ b/tests/fixtures/circuits/multibit_led_full.circ
@@ -1,0 +1,2 @@
+input[4] a
+led[4] l(in=a)

--- a/tests/fixtures/circuits/multibit_not_full.circ
+++ b/tests/fixtures/circuits/multibit_not_full.circ
@@ -1,0 +1,3 @@
+input[8] a
+not[8] inv(in=a)
+output[8] o(in=inv.out)

--- a/tests/fixtures/circuits/multibit_wire_full.circ
+++ b/tests/fixtures/circuits/multibit_wire_full.circ
@@ -1,0 +1,3 @@
+input[4] a
+wire[4] w(in=a)
+output[4] r(in=w.out)

--- a/tests/fixtures/circuits/unparametric_uses_param.circ
+++ b/tests/fixtures/circuits/unparametric_uses_param.circ
@@ -1,0 +1,2 @@
+input[W] a
+output[W] o(in=a.out)

--- a/tests/fixtures/circuits/width_default.circ
+++ b/tests/fixtures/circuits/width_default.circ
@@ -1,0 +1,3 @@
+input a, b
+and g(a=a, b=b)
+output r(in=g.out)

--- a/tests/fixtures/expected-ir/anonymous_nested.txt
+++ b/tests/fixtures/expected-ir/anonymous_nested.txt
@@ -1,14 +1,14 @@
 Module file_id=0
 Imports (0)
 Inputs (1)
-  id=0 name=a component=0
+  id=0 name=a component=0 width=1
 Outputs (1)
-  id=0 name=result driver=1.out
+  id=0 name=result driver=1.out width=1
 Components (4)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=gate kind=primitive:and_gate
-  id=2 name=__anon_0 kind=primitive:not_gate
-  id=3 name=result kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=gate kind=primitive:and_gate width=1
+  id=2 name=__anon_0 kind=primitive:not_gate width=1
+  id=3 name=result kind=primitive:output_pin width=1
 Connections (4)
   2.out -> 1.a
   0.out -> 1.b

--- a/tests/fixtures/expected-ir/multi_output.txt
+++ b/tests/fixtures/expected-ir/multi_output.txt
@@ -1,17 +1,17 @@
 Module file_id=0
 Imports (0)
 Inputs (2)
-  id=0 name=a component=0
-  id=1 name=b component=1
+  id=0 name=a component=0 width=1
+  id=1 name=b component=1 width=1
 Outputs (2)
-  id=0 name=out1 driver=2.out
-  id=1 name=out2 driver=0.out
+  id=0 name=out1 driver=2.out width=1
+  id=1 name=out2 driver=0.out width=1
 Components (5)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=b kind=primitive:input_pin
-  id=2 name=gate kind=primitive:and_gate
-  id=3 name=out1 kind=primitive:output_pin
-  id=4 name=out2 kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=b kind=primitive:input_pin width=1
+  id=2 name=gate kind=primitive:and_gate width=1
+  id=3 name=out1 kind=primitive:output_pin width=1
+  id=4 name=out2 kind=primitive:output_pin width=1
 Connections (4)
   0.out -> 2.a
   1.out -> 2.b

--- a/tests/fixtures/expected-ir/multibit_and_full.txt
+++ b/tests/fixtures/expected-ir/multibit_and_full.txt
@@ -1,0 +1,16 @@
+Module file_id=0
+Imports (0)
+Inputs (2)
+  id=0 name=a component=0 width=4
+  id=1 name=b component=1 width=4
+Outputs (1)
+  id=0 name=r driver=2.out width=4
+Components (4)
+  id=0 name=a kind=primitive:input_pin width=4
+  id=1 name=b kind=primitive:input_pin width=4
+  id=2 name=g kind=primitive:and_gate width=4
+  id=3 name=r kind=primitive:output_pin width=4
+Connections (3)
+  0.out -> 2.a
+  1.out -> 2.b
+  2.out -> 3.in

--- a/tests/fixtures/expected-ir/multibit_led_full.txt
+++ b/tests/fixtures/expected-ir/multibit_led_full.txt
@@ -1,0 +1,10 @@
+Module file_id=0
+Imports (0)
+Inputs (1)
+  id=0 name=a component=0 width=4
+Outputs (0)
+Components (2)
+  id=0 name=a kind=primitive:input_pin width=4
+  id=1 name=l kind=primitive:led width=4
+Connections (1)
+  0.out -> 1.in

--- a/tests/fixtures/expected-ir/multibit_not_full.txt
+++ b/tests/fixtures/expected-ir/multibit_not_full.txt
@@ -1,0 +1,13 @@
+Module file_id=0
+Imports (0)
+Inputs (1)
+  id=0 name=a component=0 width=8
+Outputs (1)
+  id=0 name=o driver=1.out width=8
+Components (3)
+  id=0 name=a kind=primitive:input_pin width=8
+  id=1 name=inv kind=primitive:not_gate width=8
+  id=2 name=o kind=primitive:output_pin width=8
+Connections (2)
+  0.out -> 1.in
+  1.out -> 2.in

--- a/tests/fixtures/expected-ir/multibit_wire_full.txt
+++ b/tests/fixtures/expected-ir/multibit_wire_full.txt
@@ -1,0 +1,13 @@
+Module file_id=0
+Imports (0)
+Inputs (1)
+  id=0 name=a component=0 width=4
+Outputs (1)
+  id=0 name=r driver=1.out width=4
+Components (3)
+  id=0 name=a kind=primitive:input_pin width=4
+  id=1 name=w kind=primitive:wire width=4
+  id=2 name=r kind=primitive:output_pin width=4
+Connections (2)
+  0.out -> 1.in
+  1.out -> 2.in

--- a/tests/fixtures/expected-ir/unknown_component.txt
+++ b/tests/fixtures/expected-ir/unknown_component.txt
@@ -1,13 +1,13 @@
 Module file_id=0
 Imports (0)
 Inputs (1)
-  id=0 name=a component=0
+  id=0 name=a component=0 width=1
 Outputs (1)
-  id=0 name=out driver=1.out
+  id=0 name=out driver=1.out width=1
 Components (3)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=u1 kind=unresolved_name:mystery
-  id=2 name=out kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=u1 kind=unresolved_name:mystery width=1
+  id=2 name=out kind=primitive:output_pin width=1
 Connections (2)
   0.out -> 1.in
   1.out -> 2.in

--- a/tests/fixtures/expected-ir/width_default.txt
+++ b/tests/fixtures/expected-ir/width_default.txt
@@ -4,12 +4,12 @@ Inputs (2)
   id=0 name=a component=0 width=1
   id=1 name=b component=1 width=1
 Outputs (1)
-  id=0 name=result driver=2.out width=1
+  id=0 name=r driver=2.out width=1
 Components (4)
   id=0 name=a kind=primitive:input_pin width=1
   id=1 name=b kind=primitive:input_pin width=1
-  id=2 name=gate1 kind=primitive:and_gate width=1
-  id=3 name=result kind=primitive:output_pin width=1
+  id=2 name=g kind=primitive:and_gate width=1
+  id=3 name=r kind=primitive:output_pin width=1
 Connections (3)
   0.out -> 2.a
   1.out -> 2.b

--- a/tests/fixtures/expected-ir/with_import.txt
+++ b/tests/fixtures/expected-ir/with_import.txt
@@ -2,13 +2,13 @@ Module file_id=0
 Imports (1)
   alias=dep path=dep.circ
 Inputs (1)
-  id=0 name=a component=0
+  id=0 name=a component=0 width=1
 Outputs (1)
-  id=0 name=out driver=1.out
+  id=0 name=out driver=1.out width=1
 Components (3)
-  id=0 name=a kind=primitive:input_pin
-  id=1 name=sub kind=sub_circuit_ref:dep
-  id=2 name=out kind=primitive:output_pin
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=sub kind=sub_circuit_ref:dep width=1
+  id=2 name=out kind=primitive:output_pin width=1
 Connections (2)
   0.out -> 1.a
   1.out -> 2.in

--- a/tests/helpers/ir_dump.zig
+++ b/tests/helpers/ir_dump.zig
@@ -29,20 +29,22 @@ pub fn dumpModule(allocator: std.mem.Allocator, module: anytype) ![]u8 {
 
     try writer.print("Inputs ({d})\n", .{module.inputs.len});
     for (module.inputs) |input_pin| {
-        try writer.print("  id={d} name={s} component={d}\n", .{
+        try writer.print("  id={d} name={s} component={d} width={d}\n", .{
             input_pin.id.value,
             input_pin.name,
             input_pin.component.value,
+            input_pin.width,
         });
     }
 
     try writer.print("Outputs ({d})\n", .{module.outputs.len});
     for (module.outputs) |output_pin| {
-        try writer.print("  id={d} name={s} driver={d}.{s}\n", .{
+        try writer.print("  id={d} name={s} driver={d}.{s} width={d}\n", .{
             output_pin.id.value,
             output_pin.name,
             output_pin.driver.component.value,
             output_pin.driver.port,
+            output_pin.width,
         });
     }
 
@@ -56,7 +58,7 @@ pub fn dumpModule(allocator: std.mem.Allocator, module: anytype) ![]u8 {
             try writer.writeAll("<none> kind=");
         }
         try dumpComponentKind(writer, component.kind);
-        try writer.writeByte('\n');
+        try writer.print(" width={d}\n", .{component.width});
     }
 
     try writer.print("Connections ({d})\n", .{module.connections.len});

--- a/tests/ir/resolver_test.zig
+++ b/tests/ir/resolver_test.zig
@@ -36,6 +36,31 @@ const fixtures = [_]Fixture{
         .source_path = "tests/fixtures/circuits/multi_output.circ",
         .expected_ir_path = "tests/fixtures/expected-ir/multi_output.txt",
     },
+    .{
+        .name = "multibit-and-end-to-end",
+        .source_path = "tests/fixtures/circuits/multibit_and_full.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/multibit_and_full.txt",
+    },
+    .{
+        .name = "multibit-not-end-to-end",
+        .source_path = "tests/fixtures/circuits/multibit_not_full.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/multibit_not_full.txt",
+    },
+    .{
+        .name = "multibit-wire-end-to-end",
+        .source_path = "tests/fixtures/circuits/multibit_wire_full.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/multibit_wire_full.txt",
+    },
+    .{
+        .name = "multibit-led-end-to-end",
+        .source_path = "tests/fixtures/circuits/multibit_led_full.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/multibit_led_full.txt",
+    },
+    .{
+        .name = "scalar-default-width-one",
+        .source_path = "tests/fixtures/circuits/width_default.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/width_default.txt",
+    },
 };
 
 test "resolve ast to ir fixtures" {
@@ -54,4 +79,21 @@ test "resolve ast to ir fixtures" {
             return err;
         };
     }
+}
+
+test "parameter width without introduction is a placeholder error" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const source = try std.fs.cwd().readFileAlloc(
+        allocator,
+        "tests/fixtures/circuits/unparametric_uses_param.circ",
+        1024 * 1024,
+    );
+    const ast_file = try translate.parseSource(allocator, 0, source);
+    try std.testing.expectError(
+        error.ParametricWidthNotImplemented,
+        resolver.resolve(allocator, ast_file, 0),
+    );
 }


### PR DESCRIPTION
## Summary

- Adds `width: u8` to `ir.Component`, `ir.InputPin`, `ir.OutputPin`, defaulting to 1 so all existing scalar paths continue to compile without explicit field-setting.
- Resolver reads literal widths off the AST (`Identifier.width`) on input declarations, component type names, and output declarations. Parameter-form widths (`[W]` without a `<W>` introduction) return `error.ParametricWidthNotImplemented`; this is the slot where parametric specialization will plug in later.
- Topology `.min` and `.full` serializers replace hardcoded `.width = 1` with the IR's `comp.width`, so the per-component width byte (already in the format since v02) finally carries real values.

End-to-end driving of multi-bit pins through the JS `setPin`/`getOutputState` boundary is out of scope here, that ABI is still `i32`-only and will be migrated to BigInt separately. Engine-level multi-bit simulation already works.

## Test plan

- [x] `zig build test` green, including five new IR fixtures (`multibit_and_full`, `multibit_not_full`, `multibit_wire_full`, `multibit_led_full`, `width_default`) and a negative test asserting `error.ParametricWidthNotImplemented` for `unparametric_uses_param.circ`.
- [x] Existing IR snapshots regenerate with purely additive `width=1` annotations; no other diff.
- [x] `zig build bench` shows `golden matches` on all 56 fixtures, single-bit behaviour and counters are unchanged.
- [x] New unit test `serialize: ir.Component.width threads into payload width byte` confirms that an IR module with `width=4` components produces payload width bytes of `4`.

Context: `DOCS/plan-multi-bit-language.md` §"Stage 4".

Closes #41