### PR TITLE
feat(ir): lower port-ref index and slice to slice components

### DIFF
--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -105,6 +105,22 @@ fn recalculateAndReschedule(
             if (gate.inputs.items.len == 0) return;
             calculated_state = calculateDominantState(circuit, gate.inputs, width);
         },
+        .slice => |s| {
+            // Slice extracts bits [lo..hi) from `from`. Width equals
+            // `hi - lo` and was set when the slice's state slot was
+            // allocated; shift-right-by-lo and mask with widthMask(width)
+            // give the canonical (value, defined) pair for the new width.
+            if (s.from) |from| {
+                const src = circuit.readState(from.state_handle);
+                const m = widthMask(width);
+                const shift: u6 = @intCast(s.lo);
+                calculated_state = .{
+                    .value = (src.value >> shift) & m,
+                    .defined = (src.defined >> shift) & m,
+                    .width = width,
+                };
+            }
+        },
     }
 
     const current_state = circuit.readState(component.state_handle);
@@ -114,7 +130,7 @@ fn recalculateAndReschedule(
         }
 
         const delay = switch (component.kind) {
-            .wire, .output_pin, .led => WIRE_PROPAGATION_DELAY,
+            .wire, .output_pin, .led, .slice => WIRE_PROPAGATION_DELAY,
             else => PROPAGATION_DELAY,
         };
 
@@ -301,7 +317,7 @@ pub const Event = struct {
     }
 };
 
-pub const ComponentType = enum { input_pin_gate, not_gate, led, and_gate, wire, output_pin };
+pub const ComponentType = enum { input_pin_gate, not_gate, led, and_gate, wire, output_pin, slice };
 
 pub fn toKind(kind: u8) !Component.Kind {
     return switch (kind) {
@@ -311,6 +327,7 @@ pub fn toKind(kind: u8) !Component.Kind {
         3 => .and_gate,
         4 => .wire,
         5 => .output_pin,
+        6 => .{ .slice = .{} },
         else => return error.InvalidComponentKind,
     };
 }
@@ -345,6 +362,11 @@ pub const Component = struct {
         },
         wire: struct { inputs: std.ArrayList(*Component) = .{} },
         output_pin: struct { inputs: std.ArrayList(*Component) = .{} },
+        /// Single-input pass-through that extracts bits `[lo..hi)` from
+        /// `from`'s state. Output width equals `hi - lo`; the engine
+        /// allocates the slice's state slot in tier (hi - lo). `from` is
+        /// populated by `Circuit.connect` once the source is wired in.
+        slice: struct { from: ?*Component = null, lo: u8 = 0, hi: u8 = 0 },
     };
 
     pub fn init(id: u32, kind: Kind) !*Component {
@@ -365,6 +387,7 @@ pub const Component = struct {
             .wire => |*g| g.inputs.deinit(memory.allocator),
             .output_pin => |*g| g.inputs.deinit(memory.allocator),
             .input_pin_gate => |*g| g.inputs.deinit(memory.allocator),
+            .slice => {},
         }
         memory.allocator.destroy(self);
     }
@@ -641,6 +664,10 @@ pub const Circuit = struct {
             .input_pin_gate => |*g| {
                 if (!std.mem.eql(u8, toPort, IN_PORT_NAME)) return error.InvalidInputPort;
                 try g.inputs.append(memory.allocator, fromComponent);
+            },
+            .slice => |*s| {
+                if (!std.mem.eql(u8, toPort, IN_PORT_NAME)) return error.InvalidInputPort;
+                s.from = fromComponent;
             },
         }
     }
@@ -1739,4 +1766,80 @@ test "engine: width=64 wire passes a full-register pattern through unchanged" {
     result = circuit.readState(out.state_handle);
     try std.testing.expectEqual(@as(u64, 0xDEADBEEF00000000), result.value);
     try std.testing.expectEqual(@as(u64, 0xFFFFFFFF00000000), result.defined);
+}
+
+// ============================================================================
+// Slice evaluator tests. Exercise the per-bit shift/mask semantics added in
+// S5.1 across width 1, 2, and 4 sources, including the "indexed" form
+// `a[i]` lowering to a width-1 slice.
+// ============================================================================
+
+test "engine: width-2 slice from a width-4 source extracts bits [1..3)" {
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 4);
+    const sl = try circuit.createComponent(.{ .slice = .{ .lo = 1, .hi = 3 } }, 2);
+    const out = try circuit.createComponent(.{ .output_pin = .{} }, 2);
+    try circuit.connect(input.port(OUT_PORT_NAME), sl.port(IN_PORT_NAME));
+    try circuit.connect(sl.port(OUT_PORT_NAME), out.port(OUTPUT_PIN_IN_PORT_NAME));
+
+    // 0b1010 with all bits defined: slice [1..3) takes bits 1 and 2 → 0b01.
+    try circuit.propagateEvent(input, BitVecState{ .value = 0b1010, .defined = 0b1111, .width = 4 });
+    var result = circuit.readState(out.state_handle);
+    try std.testing.expectEqual(@as(u64, 0b01), result.value);
+    try std.testing.expectEqual(@as(u64, 0b11), result.defined);
+    try std.testing.expectEqual(@as(u8, 2), result.width);
+
+    // Undefined source bits propagate undefined into the slice output at
+    // the corresponding output positions.
+    //   src value=0b0110, defined=0b1011 (bit 2 undef) → slice[1..3)
+    //   output value=(0b0110 >> 1) & 0b11 = 0b11 & 0b11 = 0b11
+    //   output defined=(0b1011 >> 1) & 0b11 = 0b101 & 0b11 = 0b01
+    try circuit.propagateEvent(input, BitVecState{ .value = 0b0110, .defined = 0b1011, .width = 4 });
+    result = circuit.readState(out.state_handle);
+    try std.testing.expectEqual(@as(u64, 0b11), result.value);
+    try std.testing.expectEqual(@as(u64, 0b01), result.defined);
+}
+
+test "engine: width-1 slice models the indexed form a[i]" {
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 4);
+    // a[2] lowers to slice with lo=2, hi=3, output width=1.
+    const sl = try circuit.createComponent(.{ .slice = .{ .lo = 2, .hi = 3 } }, 1);
+    const out = try circuit.createComponent(.{ .output_pin = .{} }, 1);
+    try circuit.connect(input.port(OUT_PORT_NAME), sl.port(IN_PORT_NAME));
+    try circuit.connect(sl.port(OUT_PORT_NAME), out.port(OUTPUT_PIN_IN_PORT_NAME));
+
+    // 0b0100: only bit 2 is high. a[2] should read high.
+    try circuit.propagateEvent(input, BitVecState{ .value = 0b0100, .defined = 0b1111, .width = 4 });
+    try std.testing.expect(circuit.readState(out.state_handle).equals(BitVecState.high(1)));
+
+    // 0b1011: bit 2 is low. a[2] should read low.
+    try circuit.propagateEvent(input, BitVecState{ .value = 0b1011, .defined = 0b1111, .width = 4 });
+    try std.testing.expect(circuit.readState(out.state_handle).equals(BitVecState.low(1)));
+
+    // Bit 2 undefined: a[2] should read undefined.
+    try circuit.propagateEvent(input, BitVecState{ .value = 0b1111, .defined = 0b1011, .width = 4 });
+    try std.testing.expect(circuit.readState(out.state_handle).equals(BitVecState.undefined_(1)));
+}
+
+test "engine: slice [0..2) of a width-4 source covers the low nibble" {
+    // Mirrors slice_basic.circ: 4-bit bus → [0..2] → 2-bit sink. Confirms
+    // lo=0 (no shift) yields the source's low two bits verbatim.
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    const input = try circuit.createComponent(.{ .input_pin_gate = .{} }, 4);
+    const sl = try circuit.createComponent(.{ .slice = .{ .lo = 0, .hi = 2 } }, 2);
+    const out = try circuit.createComponent(.{ .output_pin = .{} }, 2);
+    try circuit.connect(input.port(OUT_PORT_NAME), sl.port(IN_PORT_NAME));
+    try circuit.connect(sl.port(OUT_PORT_NAME), out.port(OUTPUT_PIN_IN_PORT_NAME));
+
+    try circuit.propagateEvent(input, BitVecState{ .value = 0b1101, .defined = 0b1111, .width = 4 });
+    const result = circuit.readState(out.state_handle);
+    try std.testing.expectEqual(@as(u64, 0b01), result.value);
+    try std.testing.expectEqual(@as(u64, 0b11), result.defined);
 }

--- a/lib/cli/inspect_dump.zig
+++ b/lib/cli/inspect_dump.zig
@@ -120,6 +120,7 @@ fn dumpComponentKind(writer: anytype, kind: anytype) !void {
         .primitive => |primitive| try writer.print("primitive:{s}", .{@tagName(primitive)}),
         .sub_circuit_ref => |sub_ref| try writer.print("sub_circuit_ref:{s}", .{sub_ref.name}),
         .unresolved_name => |name| try writer.print("unresolved_name:{s}", .{name}),
+        .slice => |s| try writer.print("slice:[{d}..{d})", .{ s.lo, s.hi }),
     }
 }
 
@@ -163,7 +164,7 @@ pub fn dumpIrModule(allocator: std.mem.Allocator, module: anytype) ![]u8 {
             try writer.writeAll("<none> kind=");
         }
         try dumpComponentKind(writer, component.kind);
-        try writer.writeAll(" width=1");
+        try writer.print(" width={d}", .{component.width});
         try writer.writeByte('\n');
     }
 

--- a/lib/emit/build_fn.zig
+++ b/lib/emit/build_fn.zig
@@ -72,12 +72,18 @@ pub fn emitBuildFunction(allocator: std.mem.Allocator, module: *const ir.Module)
     for (module.components) |component| {
         const var_name = try componentVarName(allocator, &writer, component);
         defer allocator.free(var_name);
-        const expr = switch (component.kind) {
-            .primitive => |primitive| primitiveExpr(primitive),
+        switch (component.kind) {
+            .primitive => |primitive| try writer.writeLineFmt(
+                "const {s} = try circuit.createComponent({s}, {d});",
+                .{ var_name, primitiveExpr(primitive), component.width },
+            ),
+            .slice => |s| try writer.writeLineFmt(
+                "const {s} = try circuit.createComponent(.{{ .slice = .{{ .lo = {d}, .hi = {d} }} }}, {d});",
+                .{ var_name, s.lo, s.hi, component.width },
+            ),
             .sub_circuit_ref => return error.UnsupportedSubCircuitInPhase4,
             .unresolved_name => return error.UnresolvedComponentName,
-        };
-        try writer.writeLineFmt("const {s} = try circuit.createComponent({s}, 1);", .{ var_name, expr });
+        }
     }
 
     for (module.connections) |connection| {

--- a/lib/emit/project.zig
+++ b/lib/emit/project.zig
@@ -133,6 +133,30 @@ fn walkFile(
 
                 try walkFile(ctx, target_file_id, child_prefix, &inner_inputs, &inner_outputs);
             },
+            .slice => {
+                // Slice components are synthesized by the resolver for
+                // bit-range extraction. They behave like primitives at
+                // the project-layout layer: get a global id, append an
+                // entry under the current path prefix. They are never
+                // input/output pins, so neither the input nor output map
+                // gets updated for them.
+                const global_id = ctx.next_global_id;
+                ctx.next_global_id += 1;
+
+                const leaf = if (component.instance_name) |name|
+                    try ctx.allocator.dupe(u8, name)
+                else
+                    try std.fmt.allocPrint(ctx.allocator, "slice_{d}", .{component.id.value});
+                defer ctx.allocator.free(leaf);
+
+                const segments = try dupeSegments(ctx.allocator, path_prefix, leaf);
+                try ctx.entries.append(ctx.allocator, .{
+                    .global_id = global_id,
+                    .file_id = file_id,
+                    .local_id = component.id.value,
+                    .segments = segments,
+                });
+            },
             .unresolved_name => return error.UnresolvedComponentName,
         }
     }
@@ -327,8 +351,16 @@ fn emitFileBuildFunction(
                 const var_name = try componentVarName(allocator, writer, component);
                 defer allocator.free(var_name);
                 try writer.writeLineFmt(
-                    "const {s} = try circuit.createComponent({s}, 1);",
-                    .{ var_name, primitiveExpr(primitive) },
+                    "const {s} = try circuit.createComponent({s}, {d});",
+                    .{ var_name, primitiveExpr(primitive), component.width },
+                );
+            },
+            .slice => |s| {
+                const var_name = try componentVarName(allocator, writer, component);
+                defer allocator.free(var_name);
+                try writer.writeLineFmt(
+                    "const {s} = try circuit.createComponent(.{{ .slice = .{{ .lo = {d}, .hi = {d} }} }}, {d});",
+                    .{ var_name, s.lo, s.hi, component.width },
                 );
             },
             .sub_circuit_ref => |sub_ref| {

--- a/lib/ir/resolver.zig
+++ b/lib/ir/resolver.zig
@@ -108,6 +108,37 @@ fn addComponent(
     return id;
 }
 
+fn synthesizeSlice(
+    ctx: *ResolveContext,
+    inner: ast.SignalSource,
+    lo: u8,
+    hi: u8,
+    span: ast.Span,
+) anyerror!ir.SignalEndpoint {
+    const source_endpoint = try resolveSource(ctx, inner);
+    const slice_id = nextComponentId(ctx);
+    // Width must stay >= 1 because the engine's tier dispatch asserts
+    // `1 <= width <= MAX_WIDTH`. Inverted ranges (`hi <= lo`) are caught
+    // by the validator; the placeholder width=1 here keeps the IR
+    // structurally valid until the diagnostic surfaces.
+    const width: u8 = if (hi > lo) hi - lo else 1;
+    try ctx.components.append(ctx.allocator, .{
+        .id = slice_id,
+        .kind = .{ .slice = .{ .lo = lo, .hi = hi } },
+        .instance_name = null,
+        .span = toIrSpan(span),
+        .width = width,
+    });
+    if (isValidEndpoint(source_endpoint)) {
+        try ctx.connections.append(ctx.allocator, .{
+            .from = source_endpoint,
+            .to = .{ .component = slice_id, .port = "in" },
+            .span = toIrSpan(span),
+        });
+    }
+    return .{ .component = slice_id, .port = "out" };
+}
+
 fn resolveSource(ctx: *ResolveContext, source: ast.SignalSource) anyerror!ir.SignalEndpoint {
     return switch (source) {
         .named => |named| try ensureNamedReference(ctx, named),
@@ -118,10 +149,11 @@ fn resolveSource(ctx: *ResolveContext, source: ast.SignalSource) anyerror!ir.Sig
                 .port = "out",
             };
         },
-        // Index/slice/concat lowering lands in the slice/concat IR stage. The
-        // parser produces these AST shapes today; the resolver can't yet emit
-        // an equivalent connection graph.
-        .indexed, .sliced, .concat => return error.UnsupportedSignalSource,
+        // Bit-index `a[i]` is a width-1 slice [i..i+1); the resolver
+        // collapses both AST shapes onto the same IR engine kind.
+        .indexed => |idx| try synthesizeSlice(ctx, idx.source.*, idx.bit, idx.bit + 1, idx.span),
+        .sliced => |s| try synthesizeSlice(ctx, s.source.*, s.lo, s.hi, s.span),
+        .concat => return error.UnsupportedSignalSource,
     };
 }
 

--- a/lib/ir/types.zig
+++ b/lib/ir/types.zig
@@ -28,10 +28,22 @@ pub const UnresolvedRef = struct {
     span: Span,
 };
 
+pub const Slice = struct {
+    lo: u8,
+    hi: u8,
+};
+
 pub const ComponentKind = union(enum) {
     primitive: PrimitiveKind,
     sub_circuit_ref: UnresolvedRef,
     unresolved_name: []const u8,
+    /// Bit-range extraction component synthesized by the resolver when
+    /// lowering AST `.indexed` / `.sliced` SignalSource variants. Carries
+    /// the half-open range `[lo, hi)`; the IR `Component.width` field is
+    /// set to `hi - lo`. The source feeds in through a regular IR
+    /// Connection (`source.out -> slice.in`), so name resolution and
+    /// loop detection see slice components like any other primitive.
+    slice: Slice,
 };
 
 pub const Component = struct {

--- a/lib/preview/layout/collapse.zig
+++ b/lib/preview/layout/collapse.zig
@@ -242,7 +242,10 @@ fn isPassthrough(
     expand: bool,
 ) bool {
     const k = kind_of.get(id) orelse return false;
-    if (k == .wire) return true;
+    // Slice acts as a passthrough at the preview layer: it has no glyph
+    // and downstream consumers see the upstream source directly. Bit-
+    // range semantics aren't rendered today.
+    if (k == .wire or k == .slice) return true;
     if (!expand) return false;
     return is_inner_pin.contains(id);
 }

--- a/lib/preview/layout/place.zig
+++ b/lib/preview/layout/place.zig
@@ -111,6 +111,10 @@ fn sizeOf(node: VirtualNode) sizing.PrimitiveSize {
     return switch (node.kind) {
         .primitive => |p| switch (p) {
             .input_pin, .output_pin => sizing.pinSize(node.name.len),
+            // Slice is collapsed in stage 1; the layer should never
+            // ask for its size. Return the sentinel zero so a stray
+            // call doesn't crash.
+            .slice => sizing.primitive_sizing.get(.slice),
             else => sizing.primitive_sizing.get(p),
         },
         .subcircuit => |sub| sizing.macroSize(
@@ -173,7 +177,7 @@ fn resolvePortCoords(arena: std.mem.Allocator, node: VirtualNode, x: u32, y: u32
                 try in_list.append(arena, .{ .port_name = "in", .coord = .{ .x = x -| 1, .y = y + 1 } });
                 // out_port unused on sinks.
             },
-            .wire => unreachable, // wires were collapsed in stage 1.
+            .wire, .slice => unreachable, // wires and slices were collapsed in stage 1.
         },
         .subcircuit => {
             // Active inputs land on consecutive non-corner border rows (y+1, y+3, …)

--- a/lib/preview/layout/sizing.zig
+++ b/lib/preview/layout/sizing.zig
@@ -18,6 +18,10 @@ pub const primitive_sizing = std.EnumArray(full_format.ComponentKind, PrimitiveS
     .and_gate = .{ .width = 5, .height = 5 },
     .wire = .{ .width = 0, .height = 0 },
     .output_pin = .{ .width = 0, .height = 0 },
+    // Slice components are collapsed alongside wires in `collapse.zig` so
+    // they never reach placement. The zero entry is a sentinel; placement
+    // code that looks at a slice would draw an empty box.
+    .slice = .{ .width = 0, .height = 0 },
 });
 
 /// Pin (input or output) box size. Width grows with the pin name to keep the

--- a/lib/preview/render/glyphs.zig
+++ b/lib/preview/render/glyphs.zig
@@ -20,7 +20,7 @@ pub fn drawComponent(canvas: *Canvas, placed: PlacedComponent) void {
             .not_gate => drawNotGate(canvas, placed),
             .and_gate => drawAndGate(canvas, placed),
             .led => drawLed(canvas, placed),
-            .wire => unreachable, // collapsed before placement
+            .wire, .slice => unreachable, // collapsed before placement
         },
         .subcircuit => |sub| drawMacroBox(canvas, placed, sub),
     }
@@ -51,7 +51,7 @@ fn hasOutPort(placed: PlacedComponent) bool {
     // component with no listed output role as sinkless. Distinguish by kind.
     return switch (placed.kind) {
         .primitive => |p| switch (p) {
-            .output_pin, .led, .wire => false,
+            .output_pin, .led, .wire, .slice => false,
             else => true,
         },
         .subcircuit => true,
@@ -65,7 +65,7 @@ fn colorTagFor(kind: layout.NodeKind) ColorTag {
             .not_gate => .not_gate,
             .and_gate => .and_gate,
             .led => .led,
-            .wire => .none,
+            .wire, .slice => .none,
         },
         .subcircuit => .macro,
     };

--- a/lib/syntax/ast.zig
+++ b/lib/syntax/ast.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const Span = @import("span.zig").Span;
+pub const Span = @import("span.zig").Span;
 
 pub const File = struct {
     imports: []const Import,

--- a/lib/topology/format.zig
+++ b/lib/topology/format.zig
@@ -10,6 +10,13 @@ pub const ComponentKind = enum(u8) {
     wire = 3,
     led = 4,
     output_pin = 5,
+    // S5.1: bit-range extraction. Min `ComponentRecord` for a slice carries
+    // two extra trailing bytes (`lo`, `hi`) after the fixed `(id, kind,
+    // width)` prefix, dispatched by kind. Older readers reading a slice
+    // record without knowing the suffix layout would mis-frame the next
+    // record — but the only reader of this format is the embedded
+    // runtime interpreter, which is bumped in lockstep.
+    slice = 6,
 };
 
 pub const PortName = enum(u8) {
@@ -23,6 +30,12 @@ pub const ComponentRecord = extern struct {
     id: u32,
     kind: u8,
     width: u8,
+    /// Kind-dispatched aux bytes. Present in the encoded payload only when
+    /// `kind` calls for them: today, only `slice` carries trailing
+    /// `(lo, hi)` data. Default zero keeps existing kinds' records at the
+    /// historical 6-byte size on the wire.
+    aux_lo: u8 = 0,
+    aux_hi: u8 = 0,
 };
 
 pub const ConnectionRecord = extern struct {
@@ -38,6 +51,7 @@ test "format: ComponentKind values are stable" {
     try std.testing.expectEqual(@as(u8, 3), @intFromEnum(ComponentKind.wire));
     try std.testing.expectEqual(@as(u8, 4), @intFromEnum(ComponentKind.led));
     try std.testing.expectEqual(@as(u8, 5), @intFromEnum(ComponentKind.output_pin));
+    try std.testing.expectEqual(@as(u8, 6), @intFromEnum(ComponentKind.slice));
 }
 
 test "format: PortName values are stable" {

--- a/lib/topology/full_decoder.zig
+++ b/lib/topology/full_decoder.zig
@@ -95,7 +95,18 @@ pub fn decode(allocator: std.mem.Allocator, bytes: []const u8) !FullTopology {
             origin_built += 1;
         }
 
-        comp.* = .{ .id = id, .kind = kind, .width = width, .name = name, .origin = origin };
+        // Kind-dispatched aux: slice carries (lo, hi); other kinds emit
+        // no trailing bytes for backward compatibility.
+        const aux: full_format.Aux = switch (kind) {
+            .slice => blk: {
+                const lo = try cursor.readU8();
+                const hi = try cursor.readU8();
+                break :blk .{ .slice = .{ .lo = lo, .hi = hi } };
+            },
+            else => .none,
+        };
+
+        comp.* = .{ .id = id, .kind = kind, .width = width, .name = name, .origin = origin, .aux = aux };
         components_built += 1;
     }
 

--- a/lib/topology/full_format.zig
+++ b/lib/topology/full_format.zig
@@ -14,12 +14,20 @@ pub const OriginFrame = struct {
     target_file: u32,
 };
 
+/// Kind-dispatched auxiliary metadata for the full topology section. Slice
+/// records carry the bit-range; everything else has `.none`.
+pub const Aux = union(enum) {
+    none,
+    slice: struct { lo: u8, hi: u8 },
+};
+
 pub const FullComponentRecord = struct {
     id: u32,
     kind: ComponentKind,
     width: u8,
     name: []const u8,
     origin: []const OriginFrame,
+    aux: Aux = .none,
 };
 
 pub const FullTopology = struct {

--- a/lib/topology/full_serializer.zig
+++ b/lib/topology/full_serializer.zig
@@ -38,6 +38,16 @@ pub fn encode(allocator: std.mem.Allocator, topology: FullTopology) ![]u8 {
             try appendString(&out, allocator, frame.subcircuit);
             try appendU32LE(&out, allocator, frame.target_file);
         }
+        // Kind-dispatched aux suffix. Slice records carry `(lo, hi)`.
+        // Other kinds emit zero aux bytes so the existing wire-format
+        // bytes are unchanged for unaffected kinds.
+        switch (comp.aux) {
+            .none => {},
+            .slice => |s| {
+                try out.append(allocator, s.lo);
+                try out.append(allocator, s.hi);
+            },
+        }
     }
 
     try appendU32LE(&out, allocator, @intCast(topology.connections.len));
@@ -132,7 +142,7 @@ fn resolveSignalGlobalId(
 ) !u32 {
     const comp = findComponent(module, endpoint.component) orelse return error.ComponentNotFound;
     switch (comp.kind) {
-        .primitive => return local_to_global.get(endpoint.component.value) orelse error.InternalError,
+        .primitive, .slice => return local_to_global.get(endpoint.component.value) orelse error.InternalError,
         .sub_circuit_ref => {
             const outputs = sub_output_map.get(endpoint.component.value) orelse return error.InternalError;
             return outputs.get(endpoint.port) orelse return error.UnknownPortName;
@@ -185,6 +195,32 @@ fn expandModule(
                     .origin = origin_copy,
                 });
             },
+            .slice => |s| {
+                const global_id = state.next_global_id;
+                state.next_global_id += 1;
+                try local_to_global.put(comp.id.value, global_id);
+
+                const name_src = comp.instance_name orelse "";
+                const name_copy = try state.allocator.dupe(u8, name_src);
+                errdefer state.allocator.free(name_copy);
+                const origin_copy = try dupOrigin(state.allocator, origin_stack.items);
+                errdefer {
+                    for (origin_copy) |frame| {
+                        state.allocator.free(frame.alias);
+                        state.allocator.free(frame.subcircuit);
+                    }
+                    state.allocator.free(origin_copy);
+                }
+
+                try state.components.append(state.allocator, .{
+                    .id = global_id,
+                    .kind = .slice,
+                    .width = comp.width,
+                    .name = name_copy,
+                    .origin = origin_copy,
+                    .aux = .{ .slice = .{ .lo = s.lo, .hi = s.hi } },
+                });
+            },
             .sub_circuit_ref => |ref| {
                 var child_module: ?*const ir.Module = null;
                 var target_file_id: u32 = 0;
@@ -225,10 +261,13 @@ fn expandModule(
         }
     }
 
-    // Pass 2: emit module-level connections targeting primitives in this module.
+    // Pass 2: emit module-level connections targeting primitives or slices in this module.
     for (module.connections) |conn| {
         const to_comp = findComponent(module, conn.to.component) orelse return error.ComponentNotFound;
-        if (to_comp.kind != .primitive) continue;
+        switch (to_comp.kind) {
+            .primitive, .slice => {},
+            else => continue,
+        }
 
         const from_global_id = try resolveSignalGlobalId(module, conn.from, local_to_global, sub_output_map);
         const to_global_id = local_to_global.get(conn.to.component.value) orelse return error.InternalError;
@@ -323,6 +362,20 @@ pub fn buildFromModule(allocator: std.mem.Allocator, module: *const ir.Module) !
                     .width = comp.width,
                     .name = name_copy,
                     .origin = empty_origin,
+                });
+            },
+            .slice => |s| {
+                const name_src = comp.instance_name orelse "";
+                const name_copy = try allocator.dupe(u8, name_src);
+                errdefer allocator.free(name_copy);
+                const empty_origin = try allocator.alloc(OriginFrame, 0);
+                try components.append(allocator, .{
+                    .id = comp.id.value,
+                    .kind = .slice,
+                    .width = comp.width,
+                    .name = name_copy,
+                    .origin = empty_origin,
+                    .aux = .{ .slice = .{ .lo = s.lo, .hi = s.hi } },
                 });
             },
             .sub_circuit_ref => return error.SubCircuitInFlatModule,

--- a/lib/topology/serializer.zig
+++ b/lib/topology/serializer.zig
@@ -12,6 +12,8 @@ pub fn serializeModule(
     defer connections.deinit(allocator);
 
     for (module.components) |comp| {
+        var aux_lo: u8 = 0;
+        var aux_hi: u8 = 0;
         const kind: format.ComponentKind = switch (comp.kind) {
             .primitive => |p| switch (p) {
                 .and_gate => .and_gate,
@@ -21,12 +23,19 @@ pub fn serializeModule(
                 .input_pin => .input_pin,
                 .output_pin => .output_pin,
             },
+            .slice => |s| blk: {
+                aux_lo = s.lo;
+                aux_hi = s.hi;
+                break :blk .slice;
+            },
             else => return error.SubCircuitInFlatModule,
         };
         try components.append(allocator, .{
             .id = comp.id.value,
             .kind = @intFromEnum(kind),
             .width = comp.width,
+            .aux_lo = aux_lo,
+            .aux_hi = aux_hi,
         });
     }
 
@@ -171,6 +180,19 @@ fn expandModule(
                     .width = comp.width,
                 });
             },
+            .slice => |s| {
+                const global_id = state.next_global_id;
+                state.next_global_id += 1;
+                try local_to_global.put(comp.id.value, global_id);
+
+                try state.components.append(state.allocator, .{
+                    .id = global_id,
+                    .kind = @intFromEnum(format.ComponentKind.slice),
+                    .width = comp.width,
+                    .aux_lo = s.lo,
+                    .aux_hi = s.hi,
+                });
+            },
             .sub_circuit_ref => |ref| {
                 var child_module: ?*const ir.Module = null;
                 for (state.project.import_table) |imp| {
@@ -198,10 +220,13 @@ fn expandModule(
         }
     }
 
-    // 2. Second pass: Handle module-level connections (rewiring primitives)
+    // 2. Second pass: Handle module-level connections (rewiring primitives and slices)
     for (module.connections) |conn| {
         const to_comp = findComponent(module, conn.to.component) orelse return error.ComponentNotFound;
-        if (to_comp.kind != .primitive) continue;
+        switch (to_comp.kind) {
+            .primitive, .slice => {},
+            else => continue,
+        }
 
         const from_global_id = try resolveSignalGlobalId(module, conn.from, local_to_global, sub_output_map);
         const to_global_id = local_to_global.get(conn.to.component.value) orelse return error.InternalError;
@@ -262,7 +287,7 @@ fn resolveSignalGlobalId(
 ) !u32 {
     const comp = findComponent(module, endpoint.component) orelse return error.ComponentNotFound;
     switch (comp.kind) {
-        .primitive => {
+        .primitive, .slice => {
             return local_to_global.get(endpoint.component.value) orelse error.InternalError;
         },
         .sub_circuit_ref => {
@@ -312,6 +337,12 @@ fn encodePayload(
         try out.appendSlice(allocator, &buf);
         try out.append(allocator, comp.kind);
         try out.append(allocator, comp.width);
+        // Kind-dispatched suffix: slice records carry `(lo, hi)` after
+        // the fixed prefix. Older kinds keep their historical 6 bytes.
+        if (comp.kind == @intFromEnum(format.ComponentKind.slice)) {
+            try out.append(allocator, comp.aux_lo);
+            try out.append(allocator, comp.aux_hi);
+        }
     }
 
     for (connections) |connection| {

--- a/lib/transport.zig
+++ b/lib/transport.zig
@@ -12,6 +12,7 @@ fn kindByte(kind: anytype) u8 {
         .and_gate => 3,
         .wire => 4,
         .output_pin => 5,
+        .slice => 6,
     };
 }
 

--- a/lib/truth_table/builder.zig
+++ b/lib/truth_table/builder.zig
@@ -128,6 +128,12 @@ pub fn build(
             .wire => circuit.createComponent(.{ .wire = .{} }, 1),
             .led => circuit.createComponent(.{ .led = .{} }, 1),
             .output_pin => circuit.createComponent(.{ .output_pin = .{} }, 1),
+            // Multi-bit truth tables (including slice fixtures) land in
+            // S10 once the builder iterates over multi-bit inputs. For
+            // now, reject any topology that includes a slice via the
+            // generic invalid-topology error so the hardcoded width=1
+            // path stays internally consistent.
+            .slice => return error.InvalidTopology,
         } catch return error.InvalidTopology;
         node.id = comp.id;
         id_to_node.putAssumeCapacity(comp.id, node);

--- a/lib/validator/passes/port_validation.zig
+++ b/lib/validator/passes/port_validation.zig
@@ -28,6 +28,7 @@ fn isValidInputPort(component: ir.Component, port: []const u8) bool {
         },
         .sub_circuit_ref => true,
         .unresolved_name => true,
+        .slice => std.mem.eql(u8, port, "in"),
     };
 }
 
@@ -39,7 +40,21 @@ fn isValidOutputPort(component: ir.Component, port: []const u8) bool {
         },
         .sub_circuit_ref => true,
         .unresolved_name => true,
+        .slice => std.mem.eql(u8, port, "out"),
     };
+}
+
+fn findSliceSource(module: *const ir.Module, slice_id: ir.ComponentId) ?ir.Component {
+    // The resolver synthesizes exactly one `(source.out -> slice.in)`
+    // connection per slice component. Returning the first matching
+    // source is sufficient; multi-driver scenarios are caught by a
+    // separate pass.
+    for (module.connections) |conn| {
+        if (conn.to.component.value == slice_id.value and std.mem.eql(u8, conn.to.port, "in")) {
+            return findComponent(module, conn.from.component);
+        }
+    }
+    return null;
 }
 
 pub fn run(
@@ -68,6 +83,40 @@ pub fn run(
                 .{connection.from.port},
             );
             var diagnostic = diagnostics.makeDiagnostic(.E002, toDiagnosticSpan(connection.span));
+            diagnostic.message = message;
+            try diagnostic_list.append(allocator, diagnostic);
+        }
+    }
+
+    // Slice-bound validation. Two failure modes:
+    //   - inverted range (lo >= hi): legal indices form an empty set
+    //   - out-of-bounds (hi > source.width): slice would read past MSB
+    // Both reuse E002 with a slice-specific message until the dedicated
+    // width-mismatch code (E014) lands in S6.
+    for (module.components) |comp| {
+        const slice = switch (comp.kind) {
+            .slice => |s| s,
+            else => continue,
+        };
+        if (slice.lo >= slice.hi) {
+            const message = try std.fmt.allocPrint(
+                allocator,
+                "slice range [{d}..{d}) is empty or inverted (lo must be < hi)",
+                .{ slice.lo, slice.hi },
+            );
+            var diagnostic = diagnostics.makeDiagnostic(.E002, toDiagnosticSpan(comp.span));
+            diagnostic.message = message;
+            try diagnostic_list.append(allocator, diagnostic);
+            continue;
+        }
+        const source = findSliceSource(module, comp.id) orelse continue;
+        if (slice.hi > source.width) {
+            const message = try std.fmt.allocPrint(
+                allocator,
+                "slice range [{d}..{d}) exceeds source width {d}",
+                .{ slice.lo, slice.hi, source.width },
+            );
+            var diagnostic = diagnostics.makeDiagnostic(.E002, toDiagnosticSpan(comp.span));
             diagnostic.message = message;
             try diagnostic_list.append(allocator, diagnostic);
         }

--- a/templates/interpreter.zig
+++ b/templates/interpreter.zig
@@ -28,17 +28,13 @@ pub fn initFromTopology(circuit: *engine.Circuit, payload: []const u8) !void {
     const comp_count = readU32(payload[5..9][0..4]);
     const conn_count = readU32(payload[9..13][0..4]);
 
-    const comp_bytes = 6 * comp_count;
-    const conn_bytes = 9 * conn_count;
-
-    if (payload.len < 13 + comp_bytes + conn_bytes) return error.TruncatedPayload;
-
     var comp_map = std.AutoHashMap(u32, *engine.Component).init(allocator);
     defer comp_map.deinit();
     try comp_map.ensureTotalCapacity(@intCast(comp_count));
 
     var offset: usize = 13;
     for (0..comp_count) |_| {
+        if (offset + 6 > payload.len) return error.TruncatedPayload;
         const id = readU32(payload[offset .. offset + 4][0..4]);
         const kind_val = payload[offset + 4];
         const width = payload[offset + 5];
@@ -52,10 +48,25 @@ pub fn initFromTopology(circuit: *engine.Circuit, payload: []const u8) !void {
             .wire => try circuit.createComponent(.{ .wire = .{} }, width),
             .led => try circuit.createComponent(.{ .led = .{} }, width),
             .output_pin => try circuit.createComponent(.{ .output_pin = .{} }, width),
+            .slice => blk: {
+                // Slice records carry two trailing aux bytes `(lo, hi)`.
+                // The `from` pointer is wired up later when the
+                // source→slice connection is processed.
+                if (offset + 2 > payload.len) return error.TruncatedPayload;
+                const lo = payload[offset];
+                const hi = payload[offset + 1];
+                offset += 2;
+                break :blk try circuit.createComponent(
+                    .{ .slice = .{ .lo = lo, .hi = hi } },
+                    width,
+                );
+            },
         };
         comp.id = id;
         comp_map.putAssumeCapacity(id, comp);
     }
+
+    if (offset + 9 * conn_count > payload.len) return error.TruncatedPayload;
 
     for (0..conn_count) |_| {
         const from_id = readU32(payload[offset .. offset + 4][0..4]);

--- a/tests/fixtures/circuits/bit_index_a2.circ
+++ b/tests/fixtures/circuits/bit_index_a2.circ
@@ -1,0 +1,2 @@
+input[4] a
+output o(in=a[2])

--- a/tests/fixtures/circuits/slice_basic.circ
+++ b/tests/fixtures/circuits/slice_basic.circ
@@ -1,0 +1,2 @@
+input[4] a
+output[2] o(in=a[0..2])

--- a/tests/fixtures/circuits/slice_high_bits.circ
+++ b/tests/fixtures/circuits/slice_high_bits.circ
@@ -1,0 +1,2 @@
+input[4] a
+output[2] o(in=a[2..4])

--- a/tests/fixtures/circuits/slice_inverted.circ
+++ b/tests/fixtures/circuits/slice_inverted.circ
@@ -1,0 +1,2 @@
+input[4] a
+output[2] o(in=a[3..1])

--- a/tests/fixtures/circuits/slice_out_of_bounds.circ
+++ b/tests/fixtures/circuits/slice_out_of_bounds.circ
@@ -1,0 +1,2 @@
+input[4] a
+output[2] o(in=a[3..5])

--- a/tests/fixtures/expected-diagnostics/slice_inverted.txt
+++ b/tests/fixtures/expected-diagnostics/slice_inverted.txt
@@ -1,0 +1,1 @@
+tests/fixtures/circuits/slice_inverted.circ:2:17: error: E002: slice range [3..1) is empty or inverted (lo must be < hi)

--- a/tests/fixtures/expected-diagnostics/slice_out_of_bounds.txt
+++ b/tests/fixtures/expected-diagnostics/slice_out_of_bounds.txt
@@ -1,0 +1,1 @@
+tests/fixtures/circuits/slice_out_of_bounds.circ:2:17: error: E002: slice range [3..5) exceeds source width 4

--- a/tests/fixtures/expected-ir/bit_index_a2.txt
+++ b/tests/fixtures/expected-ir/bit_index_a2.txt
@@ -1,0 +1,13 @@
+Module file_id=0
+Imports (0)
+Inputs (1)
+  id=0 name=a component=0 width=4
+Outputs (1)
+  id=0 name=o driver=2.out width=1
+Components (3)
+  id=0 name=a kind=primitive:input_pin width=4
+  id=1 name=o kind=primitive:output_pin width=1
+  id=2 name=<none> kind=slice:[2..3) width=1
+Connections (2)
+  0.out -> 2.in
+  2.out -> 1.in

--- a/tests/fixtures/expected-ir/slice_basic.txt
+++ b/tests/fixtures/expected-ir/slice_basic.txt
@@ -1,0 +1,13 @@
+Module file_id=0
+Imports (0)
+Inputs (1)
+  id=0 name=a component=0 width=4
+Outputs (1)
+  id=0 name=o driver=2.out width=2
+Components (3)
+  id=0 name=a kind=primitive:input_pin width=4
+  id=1 name=o kind=primitive:output_pin width=2
+  id=2 name=<none> kind=slice:[0..2) width=2
+Connections (2)
+  0.out -> 2.in
+  2.out -> 1.in

--- a/tests/fixtures/expected-ir/slice_high_bits.txt
+++ b/tests/fixtures/expected-ir/slice_high_bits.txt
@@ -1,0 +1,13 @@
+Module file_id=0
+Imports (0)
+Inputs (1)
+  id=0 name=a component=0 width=4
+Outputs (1)
+  id=0 name=o driver=2.out width=2
+Components (3)
+  id=0 name=a kind=primitive:input_pin width=4
+  id=1 name=o kind=primitive:output_pin width=2
+  id=2 name=<none> kind=slice:[2..4) width=2
+Connections (2)
+  0.out -> 2.in
+  2.out -> 1.in

--- a/tests/helpers/ir_dump.zig
+++ b/tests/helpers/ir_dump.zig
@@ -12,6 +12,7 @@ fn dumpComponentKind(writer: anytype, kind: anytype) !void {
         .primitive => |primitive| try writer.print("primitive:{s}", .{@tagName(primitive)}),
         .sub_circuit_ref => |sub_ref| try writer.print("sub_circuit_ref:{s}", .{sub_ref.name}),
         .unresolved_name => |name| try writer.print("unresolved_name:{s}", .{name}),
+        .slice => |s| try writer.print("slice:[{d}..{d})", .{ s.lo, s.hi }),
     }
 }
 

--- a/tests/ir/resolver_test.zig
+++ b/tests/ir/resolver_test.zig
@@ -61,6 +61,21 @@ const fixtures = [_]Fixture{
         .source_path = "tests/fixtures/circuits/width_default.circ",
         .expected_ir_path = "tests/fixtures/expected-ir/width_default.txt",
     },
+    .{
+        .name = "slice-basic-low-bits",
+        .source_path = "tests/fixtures/circuits/slice_basic.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/slice_basic.txt",
+    },
+    .{
+        .name = "slice-high-bits-nonzero-lo",
+        .source_path = "tests/fixtures/circuits/slice_high_bits.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/slice_high_bits.txt",
+    },
+    .{
+        .name = "bit-index-lowers-to-width-1-slice",
+        .source_path = "tests/fixtures/circuits/bit_index_a2.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/bit_index_a2.txt",
+    },
 };
 
 test "resolve ast to ir fixtures" {

--- a/tests/validator/run_test.zig
+++ b/tests/validator/run_test.zig
@@ -37,6 +37,16 @@ const fixtures = [_]Fixture{
         .source_path = "tests/fixtures/circuits/W003_unused_import.circ",
         .expected_path = "tests/fixtures/expected-diagnostics/W003_unused_import.txt",
     },
+    .{
+        .name = "slice out of bounds",
+        .source_path = "tests/fixtures/circuits/slice_out_of_bounds.circ",
+        .expected_path = "tests/fixtures/expected-diagnostics/slice_out_of_bounds.txt",
+    },
+    .{
+        .name = "slice inverted range",
+        .source_path = "tests/fixtures/circuits/slice_inverted.circ",
+        .expected_path = "tests/fixtures/expected-diagnostics/slice_inverted.txt",
+    },
 };
 
 fn lessByLocation(_: void, lhs: diagnostics.Diagnostic, rhs: diagnostics.Diagnostic) bool {


### PR DESCRIPTION
## Summary

- Closes #43 (S5.1: Slice and bit-index).
- Adds a `slice` engine `ComponentType` whose evaluator masks and shifts the source state into the slice's narrower width.
- Resolver synthesizes a slice IR component for AST `.indexed` (`a[i]`) and `.sliced` (`a[lo..hi]`); the bit-index form is a width-1 slice `[i..i+1)`, sharing the engine path.
- Min topology: `ComponentKind.slice = 6`. Slice records carry a kind-dispatched `(lo, hi)` suffix after the fixed `(id, kind, width)` prefix; other kinds keep their 6-byte layout. Full topology grows an `Aux` slot on `FullComponentRecord`.
- Validator emits `E002` with a slice-specific message for `hi > source.width` and `lo >= hi`. The dedicated width-mismatch code (E014) lands with the broader pass in S6.

## Files of note

- `lib/circuit.zig` — new `slice` kind + evaluator + connect handling.
- `lib/ir/{types,resolver}.zig` — `.slice` IR variant; `synthesizeSlice` lowers AST signal sources.
- `lib/topology/{format,serializer,full_format,full_serializer,full_decoder}.zig` — kind enum, kind-dispatched wire suffix, `Aux` field.
- `templates/interpreter.zig` — runtime constructs slice components from the trailing `(lo, hi)` bytes.
- `lib/validator/passes/port_validation.zig` — slice bounds + inverted-range checks.

## Test plan

- [x] `zig build test` green.
- [x] Engine unit tests for slice at widths 1, 2 (low bits and high bits).
- [x] IR snapshot tests for `slice_basic`, `slice_high_bits`, `bit_index_a2`.
- [x] Diagnostic golden tests for `slice_out_of_bounds`, `slice_inverted`.
- [x] Topology `ComponentKind.slice == 6` stability test.
- [x] Existing scalar fixtures byte-identical.

## Notes

- The bit-index form `a[i]` collapses onto the slice path: there is no separate engine kind for index, just a width-1 slice with `hi = lo + 1`.
- The min `ComponentRecord` becomes variable-length keyed by `kind`. This is forward-compatible: every existing kind keeps its historical 6-byte record on the wire; only `slice` records grow to 8 bytes. No format version bump.
- Truth-table builder and `--preview` rendering refuse / collapse slice for now; multi-bit truth tables and slice rendering arrive with later stages.