### PR TITLE
feat(ir): lower port-ref concat to concat components

### DIFF
--- a/lib/circuit.zig
+++ b/lib/circuit.zig
@@ -121,6 +121,28 @@ fn recalculateAndReschedule(
                 };
             }
         },
+        .concat => |c| {
+            // Concat ORs each operand's (defined-masked) state into
+            // position by left-shifting by the running prefix sum of
+            // operand widths. Per decision #4 the first operand occupies
+            // the low bits, so iteration order is significant.
+            var value: u64 = 0;
+            var defined: u64 = 0;
+            var prefix: u8 = 0;
+            for (c.operands.items) |op| {
+                const op_state = circuit.readState(op.state_handle);
+                const shift: u6 = @intCast(prefix);
+                value |= (op_state.value & widthMask(op_state.width)) << shift;
+                defined |= (op_state.defined & widthMask(op_state.width)) << shift;
+                prefix += op_state.width;
+            }
+            const m = widthMask(width);
+            calculated_state = .{
+                .value = value & m,
+                .defined = defined & m,
+                .width = width,
+            };
+        },
     }
 
     const current_state = circuit.readState(component.state_handle);
@@ -130,7 +152,7 @@ fn recalculateAndReschedule(
         }
 
         const delay = switch (component.kind) {
-            .wire, .output_pin, .led, .slice => WIRE_PROPAGATION_DELAY,
+            .wire, .output_pin, .led, .slice, .concat => WIRE_PROPAGATION_DELAY,
             else => PROPAGATION_DELAY,
         };
 
@@ -317,7 +339,7 @@ pub const Event = struct {
     }
 };
 
-pub const ComponentType = enum { input_pin_gate, not_gate, led, and_gate, wire, output_pin, slice };
+pub const ComponentType = enum { input_pin_gate, not_gate, led, and_gate, wire, output_pin, slice, concat };
 
 pub fn toKind(kind: u8) !Component.Kind {
     return switch (kind) {
@@ -328,6 +350,7 @@ pub fn toKind(kind: u8) !Component.Kind {
         4 => .wire,
         5 => .output_pin,
         6 => .{ .slice = .{} },
+        7 => .{ .concat = .{} },
         else => return error.InvalidComponentKind,
     };
 }
@@ -367,6 +390,12 @@ pub const Component = struct {
         /// allocates the slice's state slot in tier (hi - lo). `from` is
         /// populated by `Circuit.connect` once the source is wired in.
         slice: struct { from: ?*Component = null, lo: u8 = 0, hi: u8 = 0 },
+        /// N-input bit concatenation. `operands[i]`'s state contributes
+        /// bits `[prefix..prefix + operands[i].width)` of the output,
+        /// where `prefix` is the running sum of preceding operand widths.
+        /// Wired through `Circuit.connect` with `to_port = "operand_<i>"`;
+        /// the engine ensures the slot is set at the right index.
+        concat: struct { operands: std.ArrayList(*Component) = .{} },
     };
 
     pub fn init(id: u32, kind: Kind) !*Component {
@@ -388,6 +417,7 @@ pub const Component = struct {
             .output_pin => |*g| g.inputs.deinit(memory.allocator),
             .input_pin_gate => |*g| g.inputs.deinit(memory.allocator),
             .slice => {},
+            .concat => |*c| c.operands.deinit(memory.allocator),
         }
         memory.allocator.destroy(self);
     }
@@ -668,6 +698,18 @@ pub const Circuit = struct {
             .slice => |*s| {
                 if (!std.mem.eql(u8, toPort, IN_PORT_NAME)) return error.InvalidInputPort;
                 s.from = fromComponent;
+            },
+            .concat => |*c| {
+                // Concat operand ports are named `operand_<index>`. The
+                // index identifies the slot in the prefix-sum so the
+                // evaluator can shift each operand into the right
+                // position. The slot is filled in-place; gaps stay null.
+                if (!std.mem.startsWith(u8, toPort, "operand_")) return error.InvalidInputPort;
+                const idx = std.fmt.parseInt(usize, toPort["operand_".len..], 10) catch return error.InvalidInputPort;
+                while (c.operands.items.len <= idx) {
+                    try c.operands.append(memory.allocator, fromComponent);
+                }
+                c.operands.items[idx] = fromComponent;
             },
         }
     }
@@ -1842,4 +1884,96 @@ test "engine: slice [0..2) of a width-4 source covers the low nibble" {
     const result = circuit.readState(out.state_handle);
     try std.testing.expectEqual(@as(u64, 0b01), result.value);
     try std.testing.expectEqual(@as(u64, 0b11), result.defined);
+}
+
+// ============================================================================
+// Concat evaluator tests. Exercise the per-operand shift-and-OR semantics
+// added in S5.2 across mixed widths and undefined inputs.
+// ============================================================================
+
+test "engine: concat of four 1-bit inputs assembles a 4-bit bus" {
+    // Mirrors concat_four_bits.circ: {a, b, c, d} where each input is
+    // width=1. The low bit of the result comes from `a`, the high bit
+    // from `d`.
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    const a = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const b = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const c = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const d = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const cat = try circuit.createComponent(.{ .concat = .{} }, 4);
+    const out = try circuit.createComponent(.{ .output_pin = .{} }, 4);
+    try circuit.connect(a.port(OUT_PORT_NAME), .{ cat, "operand_0" });
+    try circuit.connect(b.port(OUT_PORT_NAME), .{ cat, "operand_1" });
+    try circuit.connect(c.port(OUT_PORT_NAME), .{ cat, "operand_2" });
+    try circuit.connect(d.port(OUT_PORT_NAME), .{ cat, "operand_3" });
+    try circuit.connect(cat.port(OUT_PORT_NAME), out.port(OUTPUT_PIN_IN_PORT_NAME));
+
+    // a=1, b=0, c=1, d=1 → result value=0b1101, defined=0b1111.
+    try circuit.propagateEvent(a, BitVecState.high(1));
+    try circuit.propagateEvent(b, BitVecState.low(1));
+    try circuit.propagateEvent(c, BitVecState.high(1));
+    try circuit.propagateEvent(d, BitVecState.high(1));
+    var result = circuit.readState(out.state_handle);
+    try std.testing.expectEqual(@as(u64, 0b1101), result.value);
+    try std.testing.expectEqual(@as(u64, 0b1111), result.defined);
+
+    // All low → all zero, fully defined.
+    try circuit.propagateEvent(a, BitVecState.low(1));
+    try circuit.propagateEvent(c, BitVecState.low(1));
+    try circuit.propagateEvent(d, BitVecState.low(1));
+    result = circuit.readState(out.state_handle);
+    try std.testing.expect(result.equals(BitVecState.low(4)));
+}
+
+test "engine: concat propagates undefined operand bits as undefined output bits" {
+    // Operand `b` is undefined; the output bit corresponding to b's
+    // position must read undefined regardless of the other operands.
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    const a = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const b = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const c = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const d = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const cat = try circuit.createComponent(.{ .concat = .{} }, 4);
+    const out = try circuit.createComponent(.{ .output_pin = .{} }, 4);
+    try circuit.connect(a.port(OUT_PORT_NAME), .{ cat, "operand_0" });
+    try circuit.connect(b.port(OUT_PORT_NAME), .{ cat, "operand_1" });
+    try circuit.connect(c.port(OUT_PORT_NAME), .{ cat, "operand_2" });
+    try circuit.connect(d.port(OUT_PORT_NAME), .{ cat, "operand_3" });
+    try circuit.connect(cat.port(OUT_PORT_NAME), out.port(OUTPUT_PIN_IN_PORT_NAME));
+
+    try circuit.propagateEvent(a, BitVecState.high(1));
+    try circuit.propagateEvent(b, BitVecState.undefined_(1));
+    try circuit.propagateEvent(c, BitVecState.high(1));
+    try circuit.propagateEvent(d, BitVecState.low(1));
+    const result = circuit.readState(out.state_handle);
+    // bit 0 = hi (a=1), bit 1 = undef (b), bit 2 = hi (c=1), bit 3 = lo (d=0)
+    try std.testing.expectEqual(@as(u64, 0b0101), result.value & result.defined);
+    try std.testing.expectEqual(@as(u64, 0b1101), result.defined);
+}
+
+test "engine: concat of mixed-width operands sums widths into output position" {
+    // Operands: a (width 2), b (width 1). Output width = 3.
+    // The low 2 bits of the output come from a; bit 2 comes from b.
+    var circuit = try Circuit.init();
+    defer circuit.deinit();
+
+    const a = try circuit.createComponent(.{ .input_pin_gate = .{} }, 2);
+    const b = try circuit.createComponent(.{ .input_pin_gate = .{} }, 1);
+    const cat = try circuit.createComponent(.{ .concat = .{} }, 3);
+    const out = try circuit.createComponent(.{ .output_pin = .{} }, 3);
+    try circuit.connect(a.port(OUT_PORT_NAME), .{ cat, "operand_0" });
+    try circuit.connect(b.port(OUT_PORT_NAME), .{ cat, "operand_1" });
+    try circuit.connect(cat.port(OUT_PORT_NAME), out.port(OUTPUT_PIN_IN_PORT_NAME));
+
+    // a = 0b10 (high bit set), b = 1 (high). Result should be 0b110.
+    try circuit.propagateEvent(a, BitVecState{ .value = 0b10, .defined = 0b11, .width = 2 });
+    try circuit.propagateEvent(b, BitVecState.high(1));
+    const result = circuit.readState(out.state_handle);
+    try std.testing.expectEqual(@as(u64, 0b110), result.value);
+    try std.testing.expectEqual(@as(u64, 0b111), result.defined);
+    try std.testing.expectEqual(@as(u8, 3), result.width);
 }

--- a/lib/cli/inspect_dump.zig
+++ b/lib/cli/inspect_dump.zig
@@ -121,6 +121,7 @@ fn dumpComponentKind(writer: anytype, kind: anytype) !void {
         .sub_circuit_ref => |sub_ref| try writer.print("sub_circuit_ref:{s}", .{sub_ref.name}),
         .unresolved_name => |name| try writer.print("unresolved_name:{s}", .{name}),
         .slice => |s| try writer.print("slice:[{d}..{d})", .{ s.lo, s.hi }),
+        .concat => try writer.writeAll("concat"),
     }
 }
 

--- a/lib/emit/build_fn.zig
+++ b/lib/emit/build_fn.zig
@@ -81,6 +81,10 @@ pub fn emitBuildFunction(allocator: std.mem.Allocator, module: *const ir.Module)
                 "const {s} = try circuit.createComponent(.{{ .slice = .{{ .lo = {d}, .hi = {d} }} }}, {d});",
                 .{ var_name, s.lo, s.hi, component.width },
             ),
+            .concat => try writer.writeLineFmt(
+                "const {s} = try circuit.createComponent(.{{ .concat = .{{}} }}, {d});",
+                .{ var_name, component.width },
+            ),
             .sub_circuit_ref => return error.UnsupportedSubCircuitInPhase4,
             .unresolved_name => return error.UnresolvedComponentName,
         }

--- a/lib/emit/project.zig
+++ b/lib/emit/project.zig
@@ -133,20 +133,26 @@ fn walkFile(
 
                 try walkFile(ctx, target_file_id, child_prefix, &inner_inputs, &inner_outputs);
             },
-            .slice => {
-                // Slice components are synthesized by the resolver for
-                // bit-range extraction. They behave like primitives at
-                // the project-layout layer: get a global id, append an
-                // entry under the current path prefix. They are never
-                // input/output pins, so neither the input nor output map
-                // gets updated for them.
+            .slice, .concat => {
+                // Slice and concat components are synthesized by the
+                // resolver for bit-range and concatenation lowering.
+                // They behave like primitives at the project-layout
+                // layer: get a global id, append an entry under the
+                // current path prefix. They are never input/output
+                // pins, so neither the input nor output map gets
+                // updated for them.
                 const global_id = ctx.next_global_id;
                 ctx.next_global_id += 1;
 
+                const fallback_prefix: []const u8 = switch (component.kind) {
+                    .slice => "slice",
+                    .concat => "concat",
+                    else => "synthetic",
+                };
                 const leaf = if (component.instance_name) |name|
                     try ctx.allocator.dupe(u8, name)
                 else
-                    try std.fmt.allocPrint(ctx.allocator, "slice_{d}", .{component.id.value});
+                    try std.fmt.allocPrint(ctx.allocator, "{s}_{d}", .{ fallback_prefix, component.id.value });
                 defer ctx.allocator.free(leaf);
 
                 const segments = try dupeSegments(ctx.allocator, path_prefix, leaf);
@@ -361,6 +367,14 @@ fn emitFileBuildFunction(
                 try writer.writeLineFmt(
                     "const {s} = try circuit.createComponent(.{{ .slice = .{{ .lo = {d}, .hi = {d} }} }}, {d});",
                     .{ var_name, s.lo, s.hi, component.width },
+                );
+            },
+            .concat => {
+                const var_name = try componentVarName(allocator, writer, component);
+                defer allocator.free(var_name);
+                try writer.writeLineFmt(
+                    "const {s} = try circuit.createComponent(.{{ .concat = .{{}} }}, {d});",
+                    .{ var_name, component.width },
                 );
             },
             .sub_circuit_ref => |sub_ref| {

--- a/lib/ir/resolver.zig
+++ b/lib/ir/resolver.zig
@@ -139,6 +139,58 @@ fn synthesizeSlice(
     return .{ .component = slice_id, .port = "out" };
 }
 
+fn lookupComponentWidth(ctx: *ResolveContext, id: ir.ComponentId) u8 {
+    // Component lists grow as the resolver walks; for a freshly
+    // synthesized operand the entry is already in `ctx.components` by
+    // the time we look it up here. Falling back to 1 keeps the
+    // arithmetic well-defined when the lookup misses (an unresolved
+    // reference, caught by a separate pass).
+    for (ctx.components.items) |comp| {
+        if (comp.id.value == id.value) return comp.width;
+    }
+    return 1;
+}
+
+fn synthesizeConcat(
+    ctx: *ResolveContext,
+    parts: []const ast.SignalSource,
+    span: ast.Span,
+) anyerror!ir.SignalEndpoint {
+    var operand_endpoints: std.ArrayList(ir.SignalEndpoint) = .{};
+    defer operand_endpoints.deinit(ctx.allocator);
+    for (parts) |part| {
+        const ep = try resolveSource(ctx, part);
+        try operand_endpoints.append(ctx.allocator, ep);
+    }
+
+    var total_width: u8 = 0;
+    for (operand_endpoints.items) |ep| {
+        if (isValidEndpoint(ep)) total_width += lookupComponentWidth(ctx, ep.component);
+    }
+    if (total_width == 0) total_width = 1;
+
+    const concat_id = nextComponentId(ctx);
+    try ctx.components.append(ctx.allocator, .{
+        .id = concat_id,
+        .kind = .concat,
+        .instance_name = null,
+        .span = toIrSpan(span),
+        .width = total_width,
+    });
+
+    for (operand_endpoints.items, 0..) |ep, idx| {
+        if (!isValidEndpoint(ep)) continue;
+        const port_name = try std.fmt.allocPrint(ctx.allocator, "operand_{d}", .{idx});
+        try ctx.connections.append(ctx.allocator, .{
+            .from = ep,
+            .to = .{ .component = concat_id, .port = port_name },
+            .span = toIrSpan(span),
+        });
+    }
+
+    return .{ .component = concat_id, .port = "out" };
+}
+
 fn resolveSource(ctx: *ResolveContext, source: ast.SignalSource) anyerror!ir.SignalEndpoint {
     return switch (source) {
         .named => |named| try ensureNamedReference(ctx, named),
@@ -153,7 +205,7 @@ fn resolveSource(ctx: *ResolveContext, source: ast.SignalSource) anyerror!ir.Sig
         // collapses both AST shapes onto the same IR engine kind.
         .indexed => |idx| try synthesizeSlice(ctx, idx.source.*, idx.bit, idx.bit + 1, idx.span),
         .sliced => |s| try synthesizeSlice(ctx, s.source.*, s.lo, s.hi, s.span),
-        .concat => return error.UnsupportedSignalSource,
+        .concat => |c| try synthesizeConcat(ctx, c.parts, c.span),
     };
 }
 

--- a/lib/ir/types.zig
+++ b/lib/ir/types.zig
@@ -44,6 +44,12 @@ pub const ComponentKind = union(enum) {
     /// Connection (`source.out -> slice.in`), so name resolution and
     /// loop detection see slice components like any other primitive.
     slice: Slice,
+    /// Bit concatenation synthesized by the resolver when lowering an
+    /// AST `.concat` SignalSource. Operand inputs flow through regular
+    /// IR Connections with port names `"operand_<i>"`; the destination
+    /// width on `Component.width` is the sum of operand widths. The
+    /// arity is implicit in how many connections target this concat.
+    concat,
 };
 
 pub const Component = struct {

--- a/lib/preview/layout/collapse.zig
+++ b/lib/preview/layout/collapse.zig
@@ -242,10 +242,10 @@ fn isPassthrough(
     expand: bool,
 ) bool {
     const k = kind_of.get(id) orelse return false;
-    // Slice acts as a passthrough at the preview layer: it has no glyph
-    // and downstream consumers see the upstream source directly. Bit-
-    // range semantics aren't rendered today.
-    if (k == .wire or k == .slice) return true;
+    // Slice and concat act as passthroughs at the preview layer: they
+    // have no glyph and downstream consumers see their upstream sources
+    // directly. Bit-range and concat semantics aren't rendered today.
+    if (k == .wire or k == .slice or k == .concat) return true;
     if (!expand) return false;
     return is_inner_pin.contains(id);
 }

--- a/lib/preview/layout/place.zig
+++ b/lib/preview/layout/place.zig
@@ -111,10 +111,10 @@ fn sizeOf(node: VirtualNode) sizing.PrimitiveSize {
     return switch (node.kind) {
         .primitive => |p| switch (p) {
             .input_pin, .output_pin => sizing.pinSize(node.name.len),
-            // Slice is collapsed in stage 1; the layer should never
-            // ask for its size. Return the sentinel zero so a stray
-            // call doesn't crash.
-            .slice => sizing.primitive_sizing.get(.slice),
+            // Slice and concat are collapsed in stage 1; the layer
+            // should never ask for their size. Return the sentinel
+            // zero so a stray call doesn't crash.
+            .slice, .concat => sizing.primitive_sizing.get(p),
             else => sizing.primitive_sizing.get(p),
         },
         .subcircuit => |sub| sizing.macroSize(
@@ -177,7 +177,7 @@ fn resolvePortCoords(arena: std.mem.Allocator, node: VirtualNode, x: u32, y: u32
                 try in_list.append(arena, .{ .port_name = "in", .coord = .{ .x = x -| 1, .y = y + 1 } });
                 // out_port unused on sinks.
             },
-            .wire, .slice => unreachable, // wires and slices were collapsed in stage 1.
+            .wire, .slice, .concat => unreachable, // wires, slices, and concats were collapsed in stage 1.
         },
         .subcircuit => {
             // Active inputs land on consecutive non-corner border rows (y+1, y+3, …)

--- a/lib/preview/layout/sizing.zig
+++ b/lib/preview/layout/sizing.zig
@@ -18,10 +18,11 @@ pub const primitive_sizing = std.EnumArray(full_format.ComponentKind, PrimitiveS
     .and_gate = .{ .width = 5, .height = 5 },
     .wire = .{ .width = 0, .height = 0 },
     .output_pin = .{ .width = 0, .height = 0 },
-    // Slice components are collapsed alongside wires in `collapse.zig` so
-    // they never reach placement. The zero entry is a sentinel; placement
-    // code that looks at a slice would draw an empty box.
+    // Slice and concat are collapsed alongside wires in `collapse.zig`
+    // so they never reach placement. The zero entries are sentinels;
+    // placement code that looked at them would draw empty boxes.
     .slice = .{ .width = 0, .height = 0 },
+    .concat = .{ .width = 0, .height = 0 },
 });
 
 /// Pin (input or output) box size. Width grows with the pin name to keep the

--- a/lib/preview/render/glyphs.zig
+++ b/lib/preview/render/glyphs.zig
@@ -20,7 +20,7 @@ pub fn drawComponent(canvas: *Canvas, placed: PlacedComponent) void {
             .not_gate => drawNotGate(canvas, placed),
             .and_gate => drawAndGate(canvas, placed),
             .led => drawLed(canvas, placed),
-            .wire, .slice => unreachable, // collapsed before placement
+            .wire, .slice, .concat => unreachable, // collapsed before placement
         },
         .subcircuit => |sub| drawMacroBox(canvas, placed, sub),
     }
@@ -51,7 +51,7 @@ fn hasOutPort(placed: PlacedComponent) bool {
     // component with no listed output role as sinkless. Distinguish by kind.
     return switch (placed.kind) {
         .primitive => |p| switch (p) {
-            .output_pin, .led, .wire, .slice => false,
+            .output_pin, .led, .wire, .slice, .concat => false,
             else => true,
         },
         .subcircuit => true,
@@ -65,7 +65,7 @@ fn colorTagFor(kind: layout.NodeKind) ColorTag {
             .not_gate => .not_gate,
             .and_gate => .and_gate,
             .led => .led,
-            .wire, .slice => .none,
+            .wire, .slice, .concat => .none,
         },
         .subcircuit => .macro,
     };

--- a/lib/topology/format.zig
+++ b/lib/topology/format.zig
@@ -17,6 +17,13 @@ pub const ComponentKind = enum(u8) {
     // record — but the only reader of this format is the embedded
     // runtime interpreter, which is bumped in lockstep.
     slice = 6,
+    // S5.2: N-input bit concatenation. Concat itself adds no trailing
+    // bytes to the `ComponentRecord`; its operand connectivity rides on
+    // the existing connections table, where the port byte is the operand
+    // index (0..N) instead of a `PortName` value. Disambiguation is
+    // context-dependent: the interpreter checks `to_comp.kind == concat`
+    // before treating the port byte as an operand index.
+    concat = 7,
 };
 
 pub const PortName = enum(u8) {
@@ -52,6 +59,7 @@ test "format: ComponentKind values are stable" {
     try std.testing.expectEqual(@as(u8, 4), @intFromEnum(ComponentKind.led));
     try std.testing.expectEqual(@as(u8, 5), @intFromEnum(ComponentKind.output_pin));
     try std.testing.expectEqual(@as(u8, 6), @intFromEnum(ComponentKind.slice));
+    try std.testing.expectEqual(@as(u8, 7), @intFromEnum(ComponentKind.concat));
 }
 
 test "format: PortName values are stable" {

--- a/lib/topology/full_serializer.zig
+++ b/lib/topology/full_serializer.zig
@@ -113,6 +113,11 @@ fn parsePortByte(name: []const u8) !u8 {
     if (std.mem.eql(u8, name, "a")) return @intFromEnum(full_format.PortName.a);
     if (std.mem.eql(u8, name, "b")) return @intFromEnum(full_format.PortName.b);
     if (std.mem.eql(u8, name, "out")) return @intFromEnum(full_format.PortName.out);
+    // Concat operand ports round-trip as the raw operand index; the
+    // decoder disambiguates by `to_comp.kind == concat`.
+    if (std.mem.startsWith(u8, name, "operand_")) {
+        return std.fmt.parseInt(u8, name["operand_".len..], 10) catch error.UnknownPortName;
+    }
     return error.UnknownPortName;
 }
 
@@ -142,7 +147,7 @@ fn resolveSignalGlobalId(
 ) !u32 {
     const comp = findComponent(module, endpoint.component) orelse return error.ComponentNotFound;
     switch (comp.kind) {
-        .primitive, .slice => return local_to_global.get(endpoint.component.value) orelse error.InternalError,
+        .primitive, .slice, .concat => return local_to_global.get(endpoint.component.value) orelse error.InternalError,
         .sub_circuit_ref => {
             const outputs = sub_output_map.get(endpoint.component.value) orelse return error.InternalError;
             return outputs.get(endpoint.port) orelse return error.UnknownPortName;
@@ -221,6 +226,31 @@ fn expandModule(
                     .aux = .{ .slice = .{ .lo = s.lo, .hi = s.hi } },
                 });
             },
+            .concat => {
+                const global_id = state.next_global_id;
+                state.next_global_id += 1;
+                try local_to_global.put(comp.id.value, global_id);
+
+                const name_src = comp.instance_name orelse "";
+                const name_copy = try state.allocator.dupe(u8, name_src);
+                errdefer state.allocator.free(name_copy);
+                const origin_copy = try dupOrigin(state.allocator, origin_stack.items);
+                errdefer {
+                    for (origin_copy) |frame| {
+                        state.allocator.free(frame.alias);
+                        state.allocator.free(frame.subcircuit);
+                    }
+                    state.allocator.free(origin_copy);
+                }
+
+                try state.components.append(state.allocator, .{
+                    .id = global_id,
+                    .kind = .concat,
+                    .width = comp.width,
+                    .name = name_copy,
+                    .origin = origin_copy,
+                });
+            },
             .sub_circuit_ref => |ref| {
                 var child_module: ?*const ir.Module = null;
                 var target_file_id: u32 = 0;
@@ -261,11 +291,11 @@ fn expandModule(
         }
     }
 
-    // Pass 2: emit module-level connections targeting primitives or slices in this module.
+    // Pass 2: emit module-level connections targeting primitives, slices, or concats in this module.
     for (module.connections) |conn| {
         const to_comp = findComponent(module, conn.to.component) orelse return error.ComponentNotFound;
         switch (to_comp.kind) {
-            .primitive, .slice => {},
+            .primitive, .slice, .concat => {},
             else => continue,
         }
 
@@ -376,6 +406,19 @@ pub fn buildFromModule(allocator: std.mem.Allocator, module: *const ir.Module) !
                     .name = name_copy,
                     .origin = empty_origin,
                     .aux = .{ .slice = .{ .lo = s.lo, .hi = s.hi } },
+                });
+            },
+            .concat => {
+                const name_src = comp.instance_name orelse "";
+                const name_copy = try allocator.dupe(u8, name_src);
+                errdefer allocator.free(name_copy);
+                const empty_origin = try allocator.alloc(OriginFrame, 0);
+                try components.append(allocator, .{
+                    .id = comp.id.value,
+                    .kind = .concat,
+                    .width = comp.width,
+                    .name = name_copy,
+                    .origin = empty_origin,
                 });
             },
             .sub_circuit_ref => return error.SubCircuitInFlatModule,

--- a/lib/topology/serializer.zig
+++ b/lib/topology/serializer.zig
@@ -28,6 +28,7 @@ pub fn serializeModule(
                 aux_hi = s.hi;
                 break :blk .slice;
             },
+            .concat => .concat,
             else => return error.SubCircuitInFlatModule,
         };
         try components.append(allocator, .{
@@ -43,7 +44,7 @@ pub fn serializeModule(
         try connections.append(allocator, .{
             .from_id = conn.from.component.value,
             .to_id = conn.to.component.value,
-            .port = @intFromEnum(try parsePortName(conn.to.port)),
+            .port = try portByteForConnection(conn.to.port),
         });
     }
 
@@ -193,6 +194,17 @@ fn expandModule(
                     .aux_hi = s.hi,
                 });
             },
+            .concat => {
+                const global_id = state.next_global_id;
+                state.next_global_id += 1;
+                try local_to_global.put(comp.id.value, global_id);
+
+                try state.components.append(state.allocator, .{
+                    .id = global_id,
+                    .kind = @intFromEnum(format.ComponentKind.concat),
+                    .width = comp.width,
+                });
+            },
             .sub_circuit_ref => |ref| {
                 var child_module: ?*const ir.Module = null;
                 for (state.project.import_table) |imp| {
@@ -220,11 +232,11 @@ fn expandModule(
         }
     }
 
-    // 2. Second pass: Handle module-level connections (rewiring primitives and slices)
+    // 2. Second pass: Handle module-level connections (rewiring primitives, slices, concats)
     for (module.connections) |conn| {
         const to_comp = findComponent(module, conn.to.component) orelse return error.ComponentNotFound;
         switch (to_comp.kind) {
-            .primitive, .slice => {},
+            .primitive, .slice, .concat => {},
             else => continue,
         }
 
@@ -234,7 +246,7 @@ fn expandModule(
         try state.connections.append(state.allocator, .{
             .from_id = from_global_id,
             .to_id = to_global_id,
-            .port = @intFromEnum(try parsePortName(conn.to.port)),
+            .port = try portByteForConnection(conn.to.port),
         });
     }
 
@@ -287,7 +299,7 @@ fn resolveSignalGlobalId(
 ) !u32 {
     const comp = findComponent(module, endpoint.component) orelse return error.ComponentNotFound;
     switch (comp.kind) {
-        .primitive, .slice => {
+        .primitive, .slice, .concat => {
             return local_to_global.get(endpoint.component.value) orelse error.InternalError;
         },
         .sub_circuit_ref => {
@@ -311,6 +323,19 @@ fn parsePortName(name: []const u8) !format.PortName {
     if (std.mem.eql(u8, name, "b")) return .b;
     if (std.mem.eql(u8, name, "out")) return .out;
     return error.UnknownPortName;
+}
+
+/// Returns the port byte for a connection's destination port. Standard
+/// port names (`in`/`a`/`b`/`out`) map through `parsePortName`; concat
+/// operand ports (`operand_<idx>`) round-trip as the raw operand index.
+/// Disambiguation at decode time is by `to_comp.kind` — concat
+/// destinations interpret the byte as an index; everything else uses
+/// `PortName`.
+fn portByteForConnection(name: []const u8) !u8 {
+    if (std.mem.startsWith(u8, name, "operand_")) {
+        return std.fmt.parseInt(u8, name["operand_".len..], 10) catch error.UnknownPortName;
+    }
+    return @intFromEnum(try parsePortName(name));
 }
 
 fn encodePayload(

--- a/lib/transport.zig
+++ b/lib/transport.zig
@@ -13,6 +13,7 @@ fn kindByte(kind: anytype) u8 {
         .wire => 4,
         .output_pin => 5,
         .slice => 6,
+        .concat => 7,
     };
 }
 

--- a/lib/truth_table/builder.zig
+++ b/lib/truth_table/builder.zig
@@ -128,12 +128,13 @@ pub fn build(
             .wire => circuit.createComponent(.{ .wire = .{} }, 1),
             .led => circuit.createComponent(.{ .led = .{} }, 1),
             .output_pin => circuit.createComponent(.{ .output_pin = .{} }, 1),
-            // Multi-bit truth tables (including slice fixtures) land in
-            // S10 once the builder iterates over multi-bit inputs. For
-            // now, reject any topology that includes a slice via the
-            // generic invalid-topology error so the hardcoded width=1
-            // path stays internally consistent.
-            .slice => return error.InvalidTopology,
+            // Multi-bit truth tables (including slice / concat
+            // fixtures) land in S10 once the builder iterates over
+            // multi-bit inputs. For now, reject any topology that
+            // includes a slice or concat via the generic
+            // invalid-topology error so the hardcoded width=1 path
+            // stays internally consistent.
+            .slice, .concat => return error.InvalidTopology,
         } catch return error.InvalidTopology;
         node.id = comp.id;
         id_to_node.putAssumeCapacity(comp.id, node);

--- a/lib/validator/passes/port_validation.zig
+++ b/lib/validator/passes/port_validation.zig
@@ -29,6 +29,10 @@ fn isValidInputPort(component: ir.Component, port: []const u8) bool {
         .sub_circuit_ref => true,
         .unresolved_name => true,
         .slice => std.mem.eql(u8, port, "in"),
+        // Concat operand ports are unbounded: any `operand_<idx>` is a
+        // valid input. The resolver always emits well-formed names, so
+        // we just check the prefix here.
+        .concat => std.mem.startsWith(u8, port, "operand_"),
     };
 }
 
@@ -41,6 +45,7 @@ fn isValidOutputPort(component: ir.Component, port: []const u8) bool {
         .sub_circuit_ref => true,
         .unresolved_name => true,
         .slice => std.mem.eql(u8, port, "out"),
+        .concat => std.mem.eql(u8, port, "out"),
     };
 }
 
@@ -115,6 +120,39 @@ pub fn run(
                 allocator,
                 "slice range [{d}..{d}) exceeds source width {d}",
                 .{ slice.lo, slice.hi, source.width },
+            );
+            var diagnostic = diagnostics.makeDiagnostic(.E002, toDiagnosticSpan(comp.span));
+            diagnostic.message = message;
+            try diagnostic_list.append(allocator, diagnostic);
+        }
+    }
+
+    // Concat width-sum validation. The resolver sets `concat.width` to
+    // the sum of operand widths at synthesis time, so the check here is
+    // "does the concat's output width equal the destination's expected
+    // input width?". Any mismatch surfaces as the user-visible "sum
+    // doesn't fit" diagnostic. E002 stands in for the dedicated
+    // E014 width-mismatch code planned for S6.
+    for (module.components) |comp| {
+        if (comp.kind != .concat) continue;
+        var operand_count: u8 = 0;
+        for (module.connections) |connection| {
+            if (connection.to.component.value == comp.id.value and
+                std.mem.startsWith(u8, connection.to.port, "operand_"))
+            {
+                operand_count += 1;
+            }
+        }
+        // Find the connection feeding concat.out into its destination.
+        for (module.connections) |connection| {
+            if (connection.from.component.value != comp.id.value) continue;
+            if (!std.mem.eql(u8, connection.from.port, "out")) continue;
+            const dest = findComponent(module, connection.to.component) orelse continue;
+            if (dest.width == comp.width) continue;
+            const message = try std.fmt.allocPrint(
+                allocator,
+                "concat width {d} from {d} operand(s) does not match destination width {d}",
+                .{ comp.width, operand_count, dest.width },
             );
             var diagnostic = diagnostics.makeDiagnostic(.E002, toDiagnosticSpan(comp.span));
             diagnostic.message = message;

--- a/templates/interpreter.zig
+++ b/templates/interpreter.zig
@@ -61,6 +61,7 @@ pub fn initFromTopology(circuit: *engine.Circuit, payload: []const u8) !void {
                     width,
                 );
             },
+            .concat => try circuit.createComponent(.{ .concat = .{} }, width),
         };
         comp.id = id;
         comp_map.putAssumeCapacity(id, comp);
@@ -77,8 +78,17 @@ pub fn initFromTopology(circuit: *engine.Circuit, payload: []const u8) !void {
         const from_comp = comp_map.get(from_id) orelse return error.UnknownComponentId;
         const to_comp = comp_map.get(to_id) orelse return error.UnknownComponentId;
 
-        const port_str = try portNameStr(port_val);
-        try circuit.connect(.{ from_comp, "out" }, .{ to_comp, port_str });
+        // Concat ports are operand indices, not PortName values. Format
+        // the byte as `operand_<idx>` so the engine's `connect()` knows
+        // to slot the operand into the right position.
+        if (to_comp.kind == .concat) {
+            var port_buf: [16]u8 = undefined;
+            const port_str = try std.fmt.bufPrint(&port_buf, "operand_{d}", .{port_val});
+            try circuit.connect(.{ from_comp, "out" }, .{ to_comp, port_str });
+        } else {
+            const port_str = try portNameStr(port_val);
+            try circuit.connect(.{ from_comp, "out" }, .{ to_comp, port_str });
+        }
     }
 }
 

--- a/tests/fixtures/circuits/concat_four_bits.circ
+++ b/tests/fixtures/circuits/concat_four_bits.circ
@@ -1,0 +1,2 @@
+input a, b, c, d
+output[4] o(in={a, b, c, d})

--- a/tests/fixtures/circuits/concat_nested.circ
+++ b/tests/fixtures/circuits/concat_nested.circ
@@ -1,0 +1,2 @@
+input a, b, c, d
+output[4] o(in={a, {b, c}, d})

--- a/tests/fixtures/circuits/concat_width_sum_mismatch.circ
+++ b/tests/fixtures/circuits/concat_width_sum_mismatch.circ
@@ -1,0 +1,2 @@
+input a, b
+output[3] o(in={a, b})

--- a/tests/fixtures/circuits/slice_then_concat.circ
+++ b/tests/fixtures/circuits/slice_then_concat.circ
@@ -1,0 +1,2 @@
+input[4] a
+output[4] o(in={a[0..2], a[2..4]})

--- a/tests/fixtures/expected-diagnostics/concat_width_sum_mismatch.txt
+++ b/tests/fixtures/expected-diagnostics/concat_width_sum_mismatch.txt
@@ -1,0 +1,1 @@
+tests/fixtures/circuits/concat_width_sum_mismatch.circ:2:16: error: E002: concat width 2 from 2 operand(s) does not match destination width 3

--- a/tests/fixtures/expected-ir/concat_four_bits.txt
+++ b/tests/fixtures/expected-ir/concat_four_bits.txt
@@ -1,0 +1,22 @@
+Module file_id=0
+Imports (0)
+Inputs (4)
+  id=0 name=a component=0 width=1
+  id=1 name=b component=1 width=1
+  id=2 name=c component=2 width=1
+  id=3 name=d component=3 width=1
+Outputs (1)
+  id=0 name=o driver=5.out width=4
+Components (6)
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=b kind=primitive:input_pin width=1
+  id=2 name=c kind=primitive:input_pin width=1
+  id=3 name=d kind=primitive:input_pin width=1
+  id=4 name=o kind=primitive:output_pin width=4
+  id=5 name=<none> kind=concat width=4
+Connections (5)
+  0.out -> 5.operand_0
+  1.out -> 5.operand_1
+  2.out -> 5.operand_2
+  3.out -> 5.operand_3
+  5.out -> 4.in

--- a/tests/fixtures/expected-ir/concat_nested.txt
+++ b/tests/fixtures/expected-ir/concat_nested.txt
@@ -1,0 +1,24 @@
+Module file_id=0
+Imports (0)
+Inputs (4)
+  id=0 name=a component=0 width=1
+  id=1 name=b component=1 width=1
+  id=2 name=c component=2 width=1
+  id=3 name=d component=3 width=1
+Outputs (1)
+  id=0 name=o driver=6.out width=4
+Components (7)
+  id=0 name=a kind=primitive:input_pin width=1
+  id=1 name=b kind=primitive:input_pin width=1
+  id=2 name=c kind=primitive:input_pin width=1
+  id=3 name=d kind=primitive:input_pin width=1
+  id=4 name=o kind=primitive:output_pin width=4
+  id=5 name=<none> kind=concat width=2
+  id=6 name=<none> kind=concat width=4
+Connections (6)
+  1.out -> 5.operand_0
+  2.out -> 5.operand_1
+  0.out -> 6.operand_0
+  5.out -> 6.operand_1
+  3.out -> 6.operand_2
+  6.out -> 4.in

--- a/tests/fixtures/expected-ir/slice_then_concat.txt
+++ b/tests/fixtures/expected-ir/slice_then_concat.txt
@@ -1,0 +1,18 @@
+Module file_id=0
+Imports (0)
+Inputs (1)
+  id=0 name=a component=0 width=4
+Outputs (1)
+  id=0 name=o driver=4.out width=4
+Components (5)
+  id=0 name=a kind=primitive:input_pin width=4
+  id=1 name=o kind=primitive:output_pin width=4
+  id=2 name=<none> kind=slice:[0..2) width=2
+  id=3 name=<none> kind=slice:[2..4) width=2
+  id=4 name=<none> kind=concat width=4
+Connections (5)
+  0.out -> 2.in
+  0.out -> 3.in
+  2.out -> 4.operand_0
+  3.out -> 4.operand_1
+  4.out -> 1.in

--- a/tests/helpers/ir_dump.zig
+++ b/tests/helpers/ir_dump.zig
@@ -13,6 +13,7 @@ fn dumpComponentKind(writer: anytype, kind: anytype) !void {
         .sub_circuit_ref => |sub_ref| try writer.print("sub_circuit_ref:{s}", .{sub_ref.name}),
         .unresolved_name => |name| try writer.print("unresolved_name:{s}", .{name}),
         .slice => |s| try writer.print("slice:[{d}..{d})", .{ s.lo, s.hi }),
+        .concat => try writer.writeAll("concat"),
     }
 }
 

--- a/tests/ir/resolver_test.zig
+++ b/tests/ir/resolver_test.zig
@@ -76,6 +76,21 @@ const fixtures = [_]Fixture{
         .source_path = "tests/fixtures/circuits/bit_index_a2.circ",
         .expected_ir_path = "tests/fixtures/expected-ir/bit_index_a2.txt",
     },
+    .{
+        .name = "concat-four-bits-into-4-bit-bus",
+        .source_path = "tests/fixtures/circuits/concat_four_bits.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/concat_four_bits.txt",
+    },
+    .{
+        .name = "concat-nested-preserves-tree-shape",
+        .source_path = "tests/fixtures/circuits/concat_nested.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/concat_nested.txt",
+    },
+    .{
+        .name = "slice-then-concat-round-trip",
+        .source_path = "tests/fixtures/circuits/slice_then_concat.circ",
+        .expected_ir_path = "tests/fixtures/expected-ir/slice_then_concat.txt",
+    },
 };
 
 test "resolve ast to ir fixtures" {

--- a/tests/validator/run_test.zig
+++ b/tests/validator/run_test.zig
@@ -47,6 +47,11 @@ const fixtures = [_]Fixture{
         .source_path = "tests/fixtures/circuits/slice_inverted.circ",
         .expected_path = "tests/fixtures/expected-diagnostics/slice_inverted.txt",
     },
+    .{
+        .name = "concat width sum mismatch",
+        .source_path = "tests/fixtures/circuits/concat_width_sum_mismatch.circ",
+        .expected_path = "tests/fixtures/expected-diagnostics/concat_width_sum_mismatch.txt",
+    },
 };
 
 fn lessByLocation(_: void, lhs: diagnostics.Diagnostic, rhs: diagnostics.Diagnostic) bool {


### PR DESCRIPTION
## Summary

- Closes #44 (S5.2: Concat).
- Builds on #59 (S5.1, now merged) — the engine, IR, topology, and validator layers learned `slice` there; this PR adds the parallel `concat` plumbing.
- Adds a `concat` engine `ComponentType` whose evaluator ORs each operand's state into position by left-shifting by the running prefix sum of operand widths (decision #4: low-on-left).
- Resolver synthesizes a concat IR component for AST `.concat { parts }`; each operand flows through a normal IR connection with port name `operand_<i>`, and concat width = sum of operand widths.
- Topology adds `ComponentKind.concat = 7`. The operand index travels on the existing `ConnectionRecord.port` byte; decoding disambiguates by inspecting `to_comp.kind == concat`. No record-layout change.
- Validator emits `E002` when the concat's summed width does not match the downstream destination's input width. The dedicated width-mismatch code (E014) lands in S6.

## Files of note

- `lib/circuit.zig` - new `concat` kind, operand-index `connect()` plumbing, shift-and-OR evaluator.
- `lib/ir/{types,resolver}.zig` - `.concat` IR variant; `synthesizeConcat` recursively resolves operands and emits one IR connection per operand.
- `lib/topology/{format,serializer,full_serializer}.zig` - kind enum, `portByteForConnection` accepts `operand_<idx>` and round-trips it as the raw index.
- `templates/interpreter.zig` - dispatches port byte by `to_comp.kind`: concat destinations format the byte as `operand_<idx>` before calling `connect()`.
- `lib/validator/passes/port_validation.zig` - concat width-sum vs destination width check.

## Test plan

- [x] `zig build test` green.
- [x] Engine unit tests at width 1 and mixed widths, including undefined operand bit propagation.
- [x] IR snapshot tests for `concat_four_bits`, `concat_nested`, `slice_then_concat`.
- [x] Diagnostic golden for `concat_width_sum_mismatch`.
- [x] Topology `ComponentKind.concat == 7` stability test.
- [x] Existing scalar fixtures byte-identical; existing slice fixtures byte-identical.

## Notes

- Nested concats are preserved as a tree of IR components rather than flattened. The IR snapshot for `{a, {b, c}, d}` shows two concat components: an inner width-2 concat for `{b, c}` and an outer width-4 concat.
- Operand connectivity rides on the connections table (with `operand_<i>` port names) rather than being inlined in the `ComponentRecord`. This keeps existing analyses (combinational loop detection, dead code) seeing the dataflow without special-casing concat.
- Preview rendering treats concat as a passthrough (collapsed in stage 1), matching the slice treatment from S5.1.