### PR TITLE
test(resolver): cover multi-parameter specialization and source-order binding

### DIFF
--- a/tests/fixtures/projects/parametric_multi/mux_lib.circ
+++ b/tests/fixtures/projects/parametric_multi/mux_lib.circ
@@ -1,0 +1,6 @@
+input<W, S>[W] data
+input<W, S>[S] select
+not[W] data_inv(in=data)
+not[S] sel_inv(in=select)
+output[W] data_out(in=data_inv.out)
+output[S] sel_out(in=sel_inv.out)

--- a/tests/fixtures/projects/parametric_multi/root.circ
+++ b/tests/fixtures/projects/parametric_multi/root.circ
@@ -1,0 +1,6 @@
+import mux "mux_lib.circ"
+input[4] x
+input[2] sel
+mux inst[4, 2](data=x, select=sel)
+output[4] y(in=inst.data_out)
+output[2] s(in=inst.sel_out)

--- a/tests/fixtures/projects/parametric_multi_3/root.circ
+++ b/tests/fixtures/projects/parametric_multi_3/root.circ
@@ -1,0 +1,8 @@
+import triple "triple_lib.circ"
+input[4] p
+input[2] q
+input[8] r
+triple inst[4, 2, 8](a=p, b=q, c=r)
+output[4] x(in=inst.a_out)
+output[2] y(in=inst.b_out)
+output[8] z(in=inst.c_out)

--- a/tests/fixtures/projects/parametric_multi_3/triple_lib.circ
+++ b/tests/fixtures/projects/parametric_multi_3/triple_lib.circ
@@ -1,0 +1,9 @@
+input<W, X, Y>[W] a
+input<W, X, Y>[X] b
+input<W, X, Y>[Y] c
+not[W] a_inv(in=a)
+not[X] b_inv(in=b)
+not[Y] c_inv(in=c)
+output[W] a_out(in=a_inv.out)
+output[X] b_out(in=b_inv.out)
+output[Y] c_out(in=c_inv.out)

--- a/tests/fixtures/projects/parametric_multi_default/mux_lib.circ
+++ b/tests/fixtures/projects/parametric_multi_default/mux_lib.circ
@@ -1,0 +1,6 @@
+input<W, S>[W] data
+input<W, S>[S] select
+not[W] data_inv(in=data)
+not[S] sel_inv(in=select)
+output[W] data_out(in=data_inv.out)
+output[S] sel_out(in=sel_inv.out)

--- a/tests/fixtures/projects/parametric_multi_default/root.circ
+++ b/tests/fixtures/projects/parametric_multi_default/root.circ
@@ -1,0 +1,6 @@
+import mux "mux_lib.circ"
+input x
+input sel
+mux inst(data=x, select=sel)
+output y(in=inst.data_out)
+output s(in=inst.sel_out)

--- a/tests/fixtures/projects/parametric_ordering/lib.circ
+++ b/tests/fixtures/projects/parametric_ordering/lib.circ
@@ -1,0 +1,6 @@
+input<W, X>[X] aux
+input<W, X>[W] data
+not[W] data_inv(in=data)
+not[X] aux_inv(in=aux)
+output[W] data_out(in=data_inv.out)
+output[X] aux_out(in=aux_inv.out)

--- a/tests/fixtures/projects/parametric_ordering/root.circ
+++ b/tests/fixtures/projects/parametric_ordering/root.circ
@@ -1,0 +1,6 @@
+import lib "lib.circ"
+input[4] x
+input[8] y
+lib inst[4, 8](data=x, aux=y)
+output[4] dout(in=inst.data_out)
+output[8] aout(in=inst.aux_out)

--- a/tests/resolver/resolve_bodies_test.zig
+++ b/tests/resolver/resolve_bodies_test.zig
@@ -142,3 +142,87 @@ test "resolve bodies propagates widths through imported sub-circuits" {
     }
     try std.testing.expect(linked_sub_ref);
 }
+
+fn lookupPinWidth(module: @import("ir_types").Module, name: []const u8, comptime kind: enum { input, output }) ?u8 {
+    return switch (kind) {
+        .input => blk: {
+            for (module.inputs) |p| {
+                if (std.mem.eql(u8, p.name, name)) break :blk p.width;
+            }
+            break :blk null;
+        },
+        .output => blk: {
+            for (module.outputs) |p| {
+                if (std.mem.eql(u8, p.name, name)) break :blk p.width;
+            }
+            break :blk null;
+        },
+    };
+}
+
+fn findSpecializedModule(project: @import("ir_types").Project, original_path_suffix: []const u8) ?@import("ir_types").Module {
+    // Synthetic spec paths are formatted "<specialization:alias@<original-path>>"
+    for (project.files, project.file_paths) |module, path| {
+        if (!std.mem.startsWith(u8, path, "<specialization:")) continue;
+        if (std.mem.indexOf(u8, path, original_path_suffix) == null) continue;
+        return module;
+    }
+    return null;
+}
+
+test "multi-parameter specialization binds widths positionally" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const project = try resolveProject(allocator, fixtureRoot("parametric_multi"));
+    const spec = findSpecializedModule(project, "mux_lib.circ") orelse return error.SpecializationMissing;
+
+    try std.testing.expectEqual(@as(u8, 4), lookupPinWidth(spec, "data", .input).?);
+    try std.testing.expectEqual(@as(u8, 2), lookupPinWidth(spec, "select", .input).?);
+    try std.testing.expectEqual(@as(u8, 4), lookupPinWidth(spec, "data_out", .output).?);
+    try std.testing.expectEqual(@as(u8, 2), lookupPinWidth(spec, "sel_out", .output).?);
+}
+
+test "three-parameter specialization extends to arity 3" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const project = try resolveProject(allocator, fixtureRoot("parametric_multi_3"));
+    const spec = findSpecializedModule(project, "triple_lib.circ") orelse return error.SpecializationMissing;
+
+    try std.testing.expectEqual(@as(u8, 4), lookupPinWidth(spec, "a", .input).?);
+    try std.testing.expectEqual(@as(u8, 2), lookupPinWidth(spec, "b", .input).?);
+    try std.testing.expectEqual(@as(u8, 8), lookupPinWidth(spec, "c", .input).?);
+}
+
+test "default-to-1 applies to all parameters when no call-site widths" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const project = try resolveProject(allocator, fixtureRoot("parametric_multi_default"));
+    const spec = findSpecializedModule(project, "mux_lib.circ") orelse return error.SpecializationMissing;
+
+    try std.testing.expectEqual(@as(u8, 1), lookupPinWidth(spec, "data", .input).?);
+    try std.testing.expectEqual(@as(u8, 1), lookupPinWidth(spec, "select", .input).?);
+    try std.testing.expectEqual(@as(u8, 1), lookupPinWidth(spec, "data_out", .output).?);
+    try std.testing.expectEqual(@as(u8, 1), lookupPinWidth(spec, "sel_out", .output).?);
+}
+
+test "parameter binding order follows source declaration, not reference" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    // lib.circ declares <W, X> but uses X first then W in input declarations.
+    // root.circ calls with [4, 8]. Per decision #9, W=4 (first declared) and X=8.
+    const project = try resolveProject(allocator, fixtureRoot("parametric_ordering"));
+    const spec = findSpecializedModule(project, "lib.circ") orelse return error.SpecializationMissing;
+
+    try std.testing.expectEqual(@as(u8, 4), lookupPinWidth(spec, "data", .input).?);
+    try std.testing.expectEqual(@as(u8, 8), lookupPinWidth(spec, "aux", .input).?);
+    try std.testing.expectEqual(@as(u8, 4), lookupPinWidth(spec, "data_out", .output).?);
+    try std.testing.expectEqual(@as(u8, 8), lookupPinWidth(spec, "aux_out", .output).?);
+}


### PR DESCRIPTION
## Summary

S7.1's binding loop already iterates over the declared parameter list generically, so multi-parameter specialization works with **zero production code changes**. This PR pins the behavior with four resolver tests and matching project fixtures so a future refactor that single-cases the loop cannot quietly regress to one-parameter only.

## What the four tests assert

| Test | Property |
| --- | --- |
| `multi-parameter specialization binds widths positionally` | 2-parameter callee at `[4, 2]` substitutes both parameters correctly |
| `three-parameter specialization extends to arity 3` | `<W, X, Y>` at `[4, 2, 8]` proves the loop scales beyond 2 |
| `default-to-1 applies to all parameters when no call-site widths` | Missing `[N, M]` defaults *every* declared parameter to 1, not just the first |
| `parameter binding order follows source declaration, not reference` | Per decision #9, binding is positional against the source order of `<W, X, ...>`, not the order parameters are first referenced inside the body |

The ordering fixture deliberately declares `<W, X>` but references `[X] aux` before `[W] data` in the body, so a wrong binding order would produce a width mismatch caught by E014.

## Test plan

- [x] `zig build test` green from a clean cache.
- [x] `zig build bench` reports `golden matches` on all 56 fixtures.
- [x] All four positive fixtures compile end-to-end via the CLI without diagnostics.

Context: `DOCS/plan-multi-bit-language.md` §"Stage 7".

Closes #47