### PR TITLE
feat(site): one-line install scripts for macOS, Linux, and Windows

### DIFF
--- a/site/public/install.ps1
+++ b/site/public/install.ps1
@@ -1,0 +1,58 @@
+# circ-compile installer for Windows (PowerShell).
+#
+#   irm https://circ-lang.org/install.ps1 | iex
+#
+# Downloads a prebuilt circ-compile.exe from https://circ-lang.org/downloads
+# and installs it. Environment overrides:
+#   $env:CIRC_VERSION       version to install (default: the latest published)
+#   $env:CIRC_INSTALL_DIR   install directory (default: %LOCALAPPDATA%\circ\bin)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$Downloads  = 'https://circ-lang.org/downloads'
+$Repo       = 'https://github.com/jeffersonmourak/circ-compiler'
+$Label      = 'windows-x86_64'   # the only Windows build; runs under emulation on ARM64
+$InstallDir = if ($env:CIRC_INSTALL_DIR) { $env:CIRC_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'circ\bin' }
+
+function Say($m) { Write-Host "circ-install: $m" }
+function Die($m) { throw "circ-install: $m" }
+
+# Resolve the version: explicit override, else the published "latest" pointer
+# (written next to the archives by tools/build-dist.sh).
+$Version = $env:CIRC_VERSION
+if (-not $Version) {
+  try { $Version = (Invoke-RestMethod -Uri "$Downloads/latest").ToString().Trim() } catch { }
+}
+if (-not $Version) { Die "could not determine the latest version; set `$env:CIRC_VERSION (see $Repo)" }
+
+$Pkg = "circ-compile-$Version-$Label"
+$Url = "$Downloads/$Pkg.zip"
+Say "installing circ-compile $Version ($Label)"
+
+$Tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("circ-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $Tmp -Force | Out-Null
+try {
+  $Zip = Join-Path $Tmp 'pkg.zip'
+  try { Invoke-WebRequest -Uri $Url -OutFile $Zip } catch { Die "download failed: $Url" }
+  Expand-Archive -Path $Zip -DestinationPath $Tmp -Force
+  $Exe = Join-Path $Tmp (Join-Path $Pkg 'circ-compile.exe')
+  if (-not (Test-Path $Exe)) { Die "archive did not contain circ-compile.exe" }
+  New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+  Copy-Item -Path $Exe -Destination (Join-Path $InstallDir 'circ-compile.exe') -Force
+} finally {
+  Remove-Item -Recurse -Force $Tmp -ErrorAction SilentlyContinue
+}
+
+Say "installed to $(Join-Path $InstallDir 'circ-compile.exe')"
+
+# Add the install dir to the user PATH if it is not already there.
+$UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if (-not $UserPath) { $UserPath = '' }
+if (($UserPath -split ';') -notcontains $InstallDir) {
+  [Environment]::SetEnvironmentVariable('Path', ($UserPath.TrimEnd(';') + ';' + $InstallDir).TrimStart(';'), 'User')
+  Say "added $InstallDir to your user PATH; open a new terminal, then run: circ-compile --help"
+} else {
+  Say "ready: run 'circ-compile --help'"
+}

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# circ-compile installer.
+#
+#   curl -fsSL https://circ-lang.org/install.sh | sh
+#
+# Downloads a prebuilt circ-compile binary from https://circ-lang.org/downloads
+# and installs it. Written in POSIX sh so it runs the same under sh, dash, or
+# bash when piped to a shell.
+#
+# Environment overrides:
+#   CIRC_VERSION       version to install (default: the latest released VERSION)
+#   CIRC_INSTALL_DIR   install directory (default: $HOME/.local/bin)
+
+set -eu
+
+DOWNLOADS="https://circ-lang.org/downloads"
+REPO="https://github.com/jeffersonmourak/circ-compiler"
+INSTALL_DIR="${CIRC_INSTALL_DIR:-$HOME/.local/bin}"
+
+say() { printf 'circ-install: %s\n' "$*"; }
+die() { printf 'circ-install: error: %s\n' "$*" >&2; exit 1; }
+
+# Pick a downloader.
+if command -v curl >/dev/null 2>&1; then
+  fetch()    { curl -fsSL "$1"; }
+  download() { curl -fsSL -o "$2" "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch()    { wget -qO- "$1"; }
+  download() { wget -qO "$2" "$1"; }
+else
+  die "curl or wget is required"
+fi
+
+# Map the platform to a release label (matches tools/build-dist.sh).
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+  Linux)
+    case "$arch" in
+      x86_64 | amd64) label="linux-x86_64" ;;
+      *) die "no prebuilt binary for Linux/$arch; build from source: $REPO" ;;
+    esac
+    ;;
+  Darwin)
+    case "$arch" in
+      arm64 | aarch64) label="macos-aarch64" ;;
+      *) die "no prebuilt binary for macOS/$arch (Apple Silicon only); build from source: $REPO" ;;
+    esac
+    ;;
+  *) die "unsupported OS '$os'; build from source: $REPO" ;;
+esac
+
+# Resolve the version: explicit override, otherwise the published "latest"
+# pointer (written next to the archives by tools/build-dist.sh, so it always
+# matches what is actually downloadable).
+version="${CIRC_VERSION:-}"
+if [ -z "$version" ]; then
+  version="$(fetch "$DOWNLOADS/latest" 2>/dev/null | tr -d '[:space:]')" || true
+fi
+[ -n "$version" ] || die "could not determine the latest version; set CIRC_VERSION=x.y.z"
+
+pkg="circ-compile-$version-$label"
+url="$DOWNLOADS/$pkg.tar.gz"
+say "installing circ-compile $version ($label)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+download "$url" "$tmp/pkg.tar.gz" || die "download failed: $url"
+tar -xzf "$tmp/pkg.tar.gz" -C "$tmp" || die "could not extract $pkg.tar.gz"
+[ -f "$tmp/$pkg/circ-compile" ] || die "archive did not contain circ-compile"
+
+mkdir -p "$INSTALL_DIR"
+cp "$tmp/$pkg/circ-compile" "$INSTALL_DIR/circ-compile"
+chmod 0755 "$INSTALL_DIR/circ-compile"
+
+# macOS: clear the quarantine flag so Gatekeeper does not block the binary.
+if [ "$os" = "Darwin" ] && command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "$INSTALL_DIR/circ-compile" >/dev/null 2>&1 || true
+fi
+
+say "installed to $INSTALL_DIR/circ-compile"
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) say "ready: run 'circ-compile --help'" ;;
+  *) say "add it to PATH:  export PATH=\"$INSTALL_DIR:\$PATH\"   (then run 'circ-compile --help')" ;;
+esac

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -60,9 +60,29 @@ const downloads = platforms.map((p) => ({
     </p>
   </aside>
 
+  <section class="install-quick">
+    <h2>Quick install</h2>
+    <p>
+      One command fetches the latest build for your platform and puts
+      <code>circ-compile</code> on your PATH.
+    </p>
+    <p><strong>macOS and Linux</strong></p>
+    <pre class="install-snippet"><code>curl -fsSL https://circ-lang.org/install.sh | sh</code></pre>
+    <br>
+    <p><strong>Windows (PowerShell)</strong></p>
+    <pre class="install-snippet"><code>irm https://circ-lang.org/install.ps1 | iex</code></pre>
+    <br>
+    <p>
+      Installs to <code>~/.local/bin</code> (macOS and Linux) or
+      <code>%LOCALAPPDATA%\circ\bin</code> (Windows). Set
+      <code>CIRC_INSTALL_DIR</code> to change the location, or
+      <code>CIRC_VERSION</code> to pin a version.
+    </p>
+  </section>
+
   <p class="download-intro">
-    Pre-built binaries for the three major desktop platforms. Prefer to build
-    from source? See the <a href={url('/reference/getting-started')}>getting-started guide</a>.
+    Or grab a specific pre-built archive by hand. Prefer to build from source?
+    See the <a href={url('/reference/getting-started')}>getting-started guide</a>.
   </p>
 
   <table class="download-table">

--- a/site/src/pages/reference/circuit-format.md
+++ b/site/src/pages/reference/circuit-format.md
@@ -6,20 +6,25 @@ description: "The .circ language: declarations, ports, components, and built-ins
 
 `.circ` files describe a digital circuit as a set of named components and their connections. The format is a simple declarative DSL designed to map directly onto the simulation engine's component and connection model.
 
-> **Status**: Parsing, semantic validation, and compilation to Zig/WASM exist for the supported surface below (`zig build`-produced WASM per sub-circuit and built-in macros).
+> **Status**: Parsing, semantic validation, and compilation to WASM exist for the supported surface below. A single root `.circ` (plus any sibling files it imports) produces one self-contained `.wasm` artifact via the in-process topology-splice pipeline; the runtime is prebuilt and embedded.
 
 ## Syntax Overview
 
-A `.circ` file contains a sequence of top-level declarations. Each declaration either names input pins or instantiates a component with named port connections.
+A `.circ` file contains a sequence of top-level declarations. Each declaration either names input pins or instantiates a component with named port connections. Every signal-carrying declaration may carry an optional width annotation `[N]` where `N` is in `[1, 64]`; a missing `[N]` means width 1.
 
 ```
-input <name> [, <name> ...]
+input  [<width>] <name> [, <name> ...]
+output [<width>] <name> [, <name> ...]
 
-<type> <name> (
+<type> [<width>] <instance-name> [<call-widths>] (
     <port> = <signal> [,
     <port> = <signal> ...]
 )
 ```
+
+`<width>` is a literal `[N]` (or a parameter inside a parametric sub-circuit; see [`language.md`](/reference) §6.3). `<call-widths>` is a comma-separated list `[w0, w1, ...]` that pins the width parameters of an imported sub-circuit at the call site.
+
+For the full language reference (parametric sub-circuits, slice/index/concat signals, the `<W>` introduction form, built-in parametric macros, and diagnostic semantics) see [`language.md`](/reference).
 
 ## Comments
 
@@ -31,9 +36,11 @@ Line comments start with `//` and run to end of line (see `Annotation` in `lib/g
 
 ```
 input pin1, pin2
+input[4] addr
+input<W>[W] data
 ```
 
-Declares one or more named input pins for the circuit. Input pins are driven externally (by the JavaScript host) and have no input ports of their own.
+Declares one or more named input pins for the circuit. Input pins are driven externally (by the host) and have no input ports of their own. An optional `[N]` after `input` makes the pin `N` bits wide; the parametric form `input<W>[W]` declares both a width parameter and an input of that width (see [`language.md`](/reference) §6.3).
 
 ### Component Instances
 
@@ -46,14 +53,17 @@ Declares one or more named input pins for the circuit. Input pins are driven ext
 
 `<type>` is the gate kind. Recognised types:
 
-| Type    | Ports    | Description           |
-|---------|----------|-----------------------|
-| `and`   | `a`, `b` | AND gate              |
-| `not`   | `in`     | NOT gate (inverter)   |
-| `led`   | `in`     | Output indicator      |
-| `wire`  | `in`     | Pass-through          |
+| Type     | Ports    | Width rule                                                                    | Description                                                         |
+|----------|----------|-------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| `and`    | `a`, `b` | bit-parallel; both inputs must match the instance width                       | AND gate                                                            |
+| `not`    | `in`     | bit-parallel; input must match the instance width                             | NOT gate (inverter)                                                 |
+| `led`    | `in`     | input must match the instance width; widths `> 1` render as a numeric display | Output indicator                                                    |
+| `wire`   | `in`     | input must match the instance width                                           | Pass-through                                                        |
+| `output` | `in`     | input must match the instance width                                           | Externally observable output pin (special-cased declaration kind)   |
 
-**Built-in macro gates** expand at compile time to nested `and` / `not` (and optionally other macros). They use **`a`** and **`b`** as input ports and expose **`out`**. Unlike `and`/`not`, **no `import`** is required — the compiler behaves as if `import … from "<builtin>/<name>.circ"` were present.
+`input` is a sibling pin declaration with its own syntax (no port list), described above. All primitives accept an optional `[N]` width annotation; absent it, width is 1.
+
+**Built-in macro gates** expand at compile time to nested `and` / `not` (and optionally other macros). They use **`a`** and **`b`** as input ports and expose **`out`**. Unlike `and`/`not`, **no `import`** is required — the compiler behaves as if `import … from "<builtin>/<name>.circ"` were present. Each macro is parametric: `or[8] g(a=x, b=y)` produces a bit-parallel 8-bit OR.
 
 | Type   | Ports    | Expansion |
 |--------|----------|-----------|
@@ -68,7 +78,12 @@ Declares one or more named input pins for the circuit. Input pins are driven ext
 `<signal>` is one of:
 - `<instance-name>.out` — the output of a named component or primitive with a single implicit output `.out`.
 - `<instance-name>.<port>` — the output pin of an imported subcircuit that exposes `<port>` (`sum`, `carry`, etc.).
-- An inline component expression (see nested components below)
+- `<signal>[i]` — single-bit index into a multi-bit signal (yields width 1).
+- `<signal>[lo..hi]` — half-open slice `[lo, hi)` of a multi-bit signal (yields width `hi - lo`).
+- `{<signal>, <signal>, ...}` — concatenation, **low operand on the left**, so `{a, b}` puts `a` in the low bits and `b` in the high bits.
+- An inline component expression (see nested components below).
+
+See [`language.md`](/reference) §4 and §6 for the full signal grammar and width-checking rules.
 
 ## Signal References
 
@@ -114,20 +129,7 @@ led result (
 
 This circuit computes `pin1 AND (NOT pin2)` and displays the result on an LED.
 
-Equivalent WASM API construction:
-
-```typescript
-const pin1    = circuit.createComponent(ComponentKind.InputPinGate);
-const pin2    = circuit.createComponent(ComponentKind.InputPinGate);
-const notGate = circuit.createComponent(ComponentKind.NotGate);
-const andGate = circuit.createComponent(ComponentKind.AndGate);
-const led     = circuit.createComponent(ComponentKind.Led);
-
-circuit.connect(pin2,    0, notGate, 1);  // pin2.out  → not.in
-circuit.connect(pin1,    0, andGate, 2);  // pin1.out  → and.a
-circuit.connect(notGate, 0, andGate, 3);  // not.out   → and.b
-circuit.connect(andGate, 0, led,     1);  // and.out   → led.in
-```
+The compiled `.wasm` does not expose a programmatic graph-construction API — the topology is baked into the artifact as a custom section and materialised by the embedded runtime at `init()`. Hosts only see the fixed export surface (`setPin`, `run`, paired `getOutputValue` / `getOutputDefined`, …) described in [`wasm-api.md`](/reference/wasm-api); the component IDs they need are emitted by `circ-compile --inspect` under each module's `Inputs (...)` / `Outputs (...)` block.
 
 ## Grammar
 
@@ -143,3 +145,17 @@ Parse tree node types used by `lib/syntax/translate.zig`:
 | `NodeType_Error`    | Parse failure at this position           |
 
 `lib/syntax/nodes/declaration.zig` handles `Declaration` rule nodes and recognises the sub-rules `input`, `output`, and `component` to determine declaration kind.
+
+## Topology Format Version
+
+Compiled `.wasm` artifacts embed the resolved circuit as a custom section. The current format identifier is `CIRC` (v02), bumped from the v01 format that preceded multi-bit support. Each serialised component now carries a `width: u8` byte; the runtime materialises the corresponding pool tier on `init()`. See [`wasm-api.md`](/reference/wasm-api) for the host-facing ABI and `lib/topology/serializer.zig` for the wire layout.
+
+## Diagnostic Codes
+
+The stable validator surface (E001–E016, W001–W003) is enumerated in [`language.md`](/reference) §4.2 and `lib/validator/codes.zig`. The multi-bit codes added with v02 are:
+
+| Code | Meaning |
+| --- | --- |
+| E014 | width mismatch between a driver and the port it feeds |
+| E015 | sub-circuit is not parametric (caller passed `[N]` call-widths to a scalar callee) |
+| E016 | parameter count mismatch (wrong number of `[w0, w1, ...]` call-widths at the call site) |

--- a/site/src/pages/reference/getting-started.md
+++ b/site/src/pages/reference/getting-started.md
@@ -106,7 +106,7 @@ Outputs (1)
   id=0 name=out driver=1.out
 ```
 
-`setPin` takes the **input pin's component id** (`0` for `a`). `getOutputState` takes the **driver component id** of the output (`1` here — the `not` gate that drives `out`), not the output_pin's own id.
+`setPin(id, value, defined)` takes the **input pin's component id** (`0` for `a`) along with a `(value, defined)` `BitVecState` pair. The paired output reads `getOutputValue(id)` and `getOutputDefined(id)` take the **driver component id** of the output (`1` here — the `not` gate that drives `out`), not the output_pin's own id.
 
 ## 4. Drive the compiled `.wasm` from Node
 
@@ -131,8 +131,14 @@ const ptr = w.topology_alloc(topoBytes.length);
 new Uint8Array(w.memory.buffer).set(topoBytes, ptr);
 
 w.init();
-w.setPin(0, 0); w.run(); console.log("a=0 -> NOT a =", w.getOutputState(1));
-w.setPin(0, 1); w.run(); console.log("a=1 -> NOT a =", w.getOutputState(1));
+
+const read = (id) =>
+  w.getOutputDefined(id) === 0n
+    ? "undefined"
+    : w.getOutputValue(id) === 0n ? "low" : "high";
+
+w.setPin(0, 0n, 1n); w.run(); console.log("a=0 -> NOT a =", read(1));
+w.setPin(0, 1n, 1n); w.run(); console.log("a=1 -> NOT a =", read(1));
 ```
 
 Run it:
@@ -144,11 +150,24 @@ node examples/run.mjs examples/inverter.wasm
 Expected:
 
 ```
-a=0 -> NOT a = 1
-a=1 -> NOT a = 0
+a=0 -> NOT a = high
+a=1 -> NOT a = low
 ```
 
-`0` means low, `1` means high, `2` means undefined. The full export list emitted by `circ-compile … -o out.wasm` today is exactly `topology_alloc`, `init`, `run`, `setPin`, `getOutputState` (plus `memory`); see [`DOCS/wasm-api.md`](/reference/wasm-api) for the full contract. The two `env` callbacks (`debugEnabled` and `onDebugLog`) are required imports — supply the no-op stubs above unless you want debug logging.
+The two i64 parameters cross the boundary as JavaScript `BigInt` values; `value` and `defined` each pack one bit per signal bit. A scalar pin uses `(0n, 1n)` for low, `(1n, 1n)` for high, and `(_, 0n)` for undefined. The full export list emitted by `circ-compile … -o out.wasm` today is exactly `topology_alloc`, `init`, `run`, `setPin`, `getOutputValue`, `getOutputDefined` (plus `memory`); see [`DOCS/wasm-api.md`](/reference/wasm-api) for the full contract. The two `env` callbacks (`debugEnabled` and `onDebugLog`) are required imports — supply the no-op stubs above unless you want debug logging.
+
+### Driving a multi-bit input
+
+For a wider input declared as `input[4] a`, both `value` and `defined` use one bit per signal bit. To drive a 4-bit bus to the value `0b1010` with every bit defined:
+
+```js
+w.setPin(input_id, 0b1010n, 0b1111n);
+w.run();
+const v = w.getOutputValue(output_id);   // BigInt, e.g. 0b1010n for a passthrough
+const d = w.getOutputDefined(output_id); // BigInt, 0b1111n
+```
+
+Bits set beyond the declared width are silently masked. See [`DOCS/wasm-api.md`](/reference/wasm-api) for the full `BitVecState` semantics.
 
 ## 5. Use a built-in macro (`xor`)
 
@@ -175,8 +194,9 @@ Once a file participates in the project pipeline, root-pin component IDs are ass
 
 ```js
 for (let i = 0; i < 64; i++) {
-  const v = w.getOutputState(i);
-  if (v !== 2) console.log(`id=${i} -> ${v}`);
+  if (w.getOutputDefined(i) !== 0n) {
+    console.log(`id=${i} -> value=${w.getOutputValue(i)} defined=${w.getOutputDefined(i)}`);
+  }
 }
 ```
 

--- a/site/src/pages/reference/preview.md
+++ b/site/src/pages/reference/preview.md
@@ -48,6 +48,7 @@ The `[xor:g]` box represents the entire `xor g(...)` instance as a single labele
 |------|---------|
 | `--preview` | Selects preview mode. Mutually exclusive with `--emit-zig` and `--inspect`. `-o` is rejected at parse time. |
 | `--expand-macros` | Renders subcircuits as their full primitive expansion instead of as a single labeled box. Only valid with `--preview`. |
+| `--expand-display` | Renders an `led[N]` (width > 1) as a row of `N` single-bit LED cells with explicit `b0..bN-1` slice connections, instead of the default opaque multi-bit numeric display box. Only valid with `--preview`. |
 | `--color=auto\|always\|never` | Enables ANSI color (per-kind: input pins green, gates cyan, LEDs yellow, macros magenta, wires dim). Defaults to `auto` (color when stdout is a TTY *and* `NO_COLOR` is unset). `always` overrides `NO_COLOR` per the convention used by `git`/`ls`/`grep`. |
 
 The render path is fully in-memory: parse → resolve → translate → topology build → layout → render → stdout. No `.wasm` is written, no temp directory, no subprocess.
@@ -80,6 +81,30 @@ Names longer than the cell width are truncated; shorter names pad with spaces. T
 
 **Layout determinism.** Rendering uses a five-stage pipeline (collapse → columns → rows → place → route), followed by a junction-picker pass that resolves crossings into the right corner/T-glyph. Every decision uses ascending node id as the universal tie-breaker; hash-map iteration is forbidden as an ordering source. The same `.circ` source produces byte-identical output across runs and platforms.
 
+## Multi-bit pins
+
+A component declared with a width annotation (`input[4] a`, `led[4] disp`, `wire[8] bus`) renders with the width appended to its label as `[N]`:
+
+```
+╭──────╮     ╭────────────╮
+│ a[4] ├○───▶┤ [led:disp] │
+╰──────╯     ╰────────────╯
+```
+
+A scalar pin omits the suffix, so the label width-marker is the visual cue that distinguishes a 1-bit and an N-bit wire. The wire glyph itself is the same — there is no "bus" glyph.
+
+### LED rendering modes
+
+A multi-bit `led[N]` (width > 1) has three rendering modes:
+
+| Mode | Trigger | Cell content |
+|------|---------|--------------|
+| **Numeric** | width > 1, all bits `defined` | The unsigned integer value (`0`–`2^N-1`) inside the box. |
+| **Numeric + warning** | width > 1, some bits `defined`, others `undefined` | The integer value formed from the defined bits, with a warning marker (`?`) showing partial state. |
+| **Indicator** | width = 1 | The single-bit LED glyph: lit on `high`, dim on `low`, `?` on `undefined`. |
+
+With `--expand-display`, the multi-bit form decomposes into `N` scalar LEDs wired to explicit bit-index slices of the input signal, which is the right view when you need to debug per-bit drive state.
+
 ## Macro modes
 
 Built-in macros (`or`, `nand`, `nor`, `xor`, `xnor`) and user-imported subcircuits expand into primitive gates during compilation. The renderer can display them two ways:
@@ -93,8 +118,8 @@ The renderer reads from a versioned topology payload embedded in compiled `.wasm
 
 | Section | Contains |
 |---------|----------|
-| `circ.topology.v0.min` | Flat primitive components (id, kind) + connections. Magic `CIRC`, version `0x01`. The "lightweight" payload — what the runtime needs. |
-| `circ.topology.v0.full` | Adds per-component instance names + subcircuit-origin chains. Magic `CIRF`, version `0x01`. The "rich" payload — what the renderer (and any future inspection tooling) needs. |
+| `circ.topology.v0.min` | Flat primitive components (id, kind, `width: u8`) + connections. Magic `CIRC`, version `0x02`. The "lightweight" payload — what the runtime needs. |
+| `circ.topology.v0.full` | Adds per-component instance names + subcircuit-origin chains. Magic `CIRF`, version `0x02`. The "rich" payload — what the renderer (and any future inspection tooling) needs. |
 
 `--preview` builds the `full` payload in memory (skipping the `.wasm` write) and feeds it directly into the renderer. Tools that consume a `.wasm` artifact from disk can parse the same payload via `lib/topology/full_decoder.zig:decode`.
 

--- a/site/src/pages/reference/wasm-api.md
+++ b/site/src/pages/reference/wasm-api.md
@@ -22,21 +22,24 @@ If `debugEnabled` returns `0`, `onDebugLog` is never called, but **both imports 
 ## Exports (WASM → host)
 
 ```
-memory:          WebAssembly.Memory
-topology_alloc:  (len: i32) => i32     // host buffer for topology bytes; returns ptr (or -1 on OOM)
-init:            ()        => void    // construct circuit from the topology buffer
-run:             ()        => void    // drain the event queue until the circuit settles
-setPin:          (id: i32, state: i32) => void
-getOutputState:  (id: i32) => i32
+memory:             WebAssembly.Memory
+topology_alloc:     (len: i32) => i32                      // host buffer for topology bytes; returns ptr (or -1 on OOM)
+init:               ()        => void                       // construct circuit from the topology buffer
+run:                ()        => void                       // drain the event queue until the circuit settles
+setPin:             (id: i32, value: i64, defined: i64) => void
+getOutputValue:     (id: i32) => i64                        // BitVecState.value of the component's output
+getOutputDefined:   (id: i32) => i64                        // BitVecState.defined of the component's output
 ```
 
-`state` integer encoding (matches `engine.State.toInt`/`fromInt` in `lib/circuit.zig`):
+The i64 fields cross the JS↔WASM boundary as `BigInt`. A component's state is a `BitVecState`-shaped `(value, defined)` pair where each bit of `defined` says whether the corresponding bit of `value` is meaningful:
 
-| Integer | State        |
-|---------|--------------|
-| `0`     | low          |
-| `1`     | high         |
-| `2`     | undefined    |
+| `defined` bit | `value` bit | Interpretation |
+|---------------|-------------|----------------|
+| `1`           | `0`         | low            |
+| `1`           | `1`         | high           |
+| `0`           | (ignored)   | undefined      |
+
+For a width-`W` component, only the low `W` bits of each i64 are meaningful; bits beyond `W` are zero on read and silently dropped on write.
 
 ### `topology_alloc(len)` and `init()`
 
@@ -55,15 +58,24 @@ Drains the engine's event queue until empty. Settling delays are `5` time-units 
 
 `run()` is a no-op if `init()` has not run successfully.
 
-### `setPin(component_id, state)`
+### `setPin(component_id, value, defined)`
 
-Drives a top-level input pin. `component_id` is the global integer ID of an `input_pin_gate`; passing the ID of a non-input or out-of-range component is a silent no-op (it does not throw or trap).
+Drives a top-level input pin to the BitVecState `(value, defined)`. `component_id` is the global integer ID of an `input_pin_gate`; passing the ID of a non-input or out-of-range component is a silent no-op (it does not throw or trap).
+
+For width-1 inputs the usual encodings are `setPin(id, 0n, 1n)` for low, `setPin(id, 1n, 1n)` for high, and `setPin(id, 0n, 0n)` for undefined. For wider inputs each bit of `value` and `defined` corresponds to a bit position; bits set beyond the component's declared width are masked silently.
 
 `setPin` only enqueues the change — call `run()` after to propagate it.
 
-### `getOutputState(component_id)`
+### `getOutputValue(component_id)` and `getOutputDefined(component_id)`
 
-Returns the current `output_state` of the component with the given ID, encoded as the integer above. Returns `2` (undefined) if the runtime is not initialised or the ID is out of range. The argument is the **driver component ID**, not an output-pin index — for an `output out(in=inv.out)` declaration, you pass `inv`'s component ID, not `out`'s pin ID. The `--inspect` output of the compiler prints this mapping under its `Outputs (...)` block.
+Paired exports. Each call returns one of the two `BitVecState` fields of the component's current output. Returns `0n` for both if the runtime is not initialised or the ID is out of range — the host distinguishes "definitely low" from "undefined" by checking `getOutputDefined` first. The argument is the **driver component ID**, not an output-pin index — for an `output out(in=inv.out)` declaration, you pass `inv`'s component ID, not `out`'s pin ID. The `--inspect` output of the compiler prints this mapping under its `Outputs (...)` block.
+
+#### Why paired exports instead of one out-pointer call
+
+A previous draft considered a single-call shape: `getOutputState(id, out_ptr: i32)` that wrote a 16-byte `BitVecState` into linear memory at `out_ptr`. Two reasons the paired-export shape won:
+
+- **Simpler host code.** Two function calls return BigInts that the host combines directly. No buffer allocation, no pointer arithmetic, no in-band encoding to standardise (endianness, alignment, sentinel for undefined).
+- **The 2× call overhead is irrelevant in practice.** Hosts typically read once after settle, not in a hot loop. If a future use case needs batched reads, a sibling export (`getOutputStateBatch(ids_ptr, out_ptr, count)`) can be added without breaking the paired API.
 
 ## Custom sections
 
@@ -98,11 +110,34 @@ new Uint8Array(w.memory.buffer).set(topoBytes, ptr);
 
 // 2. Build the circuit and drive it.
 w.init();
-w.setPin(0, 1);                  // pin id=0 → high
+w.setPin(0, 1n, 1n);                            // pin id=0 → high (value=1, defined=1)
 w.run();
-console.log(w.getOutputState(1)); // 0 = low (NOT of high)
+const value   = w.getOutputValue(1);            // BigInt
+const defined = w.getOutputDefined(1);          // BigInt
+console.log(defined === 0n
+  ? "undefined"
+  : value === 0n ? "low" : "high");             // "low" (NOT of high)
+```
+
+For wider inputs, the helper pattern is:
+
+```js
+// Drive a width-4 input bus to the value 0b1010, all four bits defined.
+w.setPin(input_id, 0b1010n, 0b1111n);
+w.run();
+const v = w.getOutputValue(output_id);  // e.g. 0b1010n for a passthrough
+const d = w.getOutputDefined(output_id); // 0b1111n
+```
+
+To collapse a paired read back into the legacy 3-state encoding when integrating with code that still uses it:
+
+```js
+const readScalar = (id) =>
+  w.getOutputDefined(id) === 0n
+    ? 2                               // undefined
+    : w.getOutputValue(id) === 0n ? 0 : 1; // low / high
 ```
 
 ## Things that are *not* exports today
 
-Earlier drafts of this project anticipated additional exports — `deinit`, `reset`, `stop`, `getStateSnapshot`, `getTopology`, `getPendingEvents`, `getFileInfo`, `freeBuffer` — and a separate `onStateChange` import. None of these are present in the artifact produced by `circ-compile … -o out.wasm` today. They exist only in `lib/emit/runtime.zig`, the experimental `--emit-zig` pipeline, and may appear in a future runtime version. If your host needs change-notifications, poll `getOutputState` after each `run()`.
+Earlier drafts of this project anticipated additional exports — `deinit`, `reset`, `stop`, `getStateSnapshot`, `getTopology`, `getPendingEvents`, `getFileInfo`, `freeBuffer` — and a separate `onStateChange` import. None of these are present in the artifact produced by `circ-compile … -o out.wasm` today. The extra exports survive only in `lib/emit/runtime.zig`, the experimental `--emit-zig` pipeline; the `onStateChange` import was never wired into any pipeline and exists nowhere in the codebase. Either may appear in a future runtime version. If your host needs change-notifications, poll `getOutputValue` / `getOutputDefined` after each `run()`.

--- a/tools/build-dist.sh
+++ b/tools/build-dist.sh
@@ -57,6 +57,10 @@ build_one x86_64-linux-musl   circ-compile      linux-x86_64
 build_one aarch64-macos       circ-compile      macos-aarch64
 build_one x86_64-windows-gnu  circ-compile.exe  windows-x86_64
 
+# Plain-text "latest" pointer the install script (site/public/install.sh)
+# reads to resolve the current version, kept in lockstep with the archives.
+printf '%s\n' "$VERSION" > "$DOWNLOADS/latest"
+
 echo
 echo "Done. Archives in $DOWNLOADS:"
 ls -lh "$DOWNLOADS"


### PR DESCRIPTION
## What

One-line installers that fetch a prebuilt `circ-compile` for the user's platform:

- macOS / Linux: `curl -fsSL https://circ-lang.org/install.sh | sh`
- Windows (PowerShell): `irm https://circ-lang.org/install.ps1 | iex`

Both resolve the version from a `downloads/latest` pointer (so they always match
what is actually published), honor `CIRC_VERSION` and `CIRC_INSTALL_DIR`, and
install to `~/.local/bin` or `%LOCALAPPDATA%\circ\bin`. The Download page gains a
"Quick install" section showing both, and `tools/build-dist.sh` now writes the
`latest` pointer next to the archives.

## Notes

- The shell script is POSIX (verified under `sh` and `dash`) and was run end to
  end against the live site. The PowerShell script was reviewed statically but
  not executed (no `pwsh` available when authoring); it should get one run on
  Windows.
- Go-live needs `tools/build-dist.sh` re-run on `main` (to publish the current
  archives plus the new `latest` pointer) and a site deploy. Until then the
  one-liners are correct but the default version lookup has nothing to resolve
  to; `CIRC_VERSION=<x.y.z>` is the escape hatch.
