### PR TITLE
test(topology): cover multi-bit, undefined, and datapath behavior

### DIFF
--- a/lib/topology/serializer.zig
+++ b/lib/topology/serializer.zig
@@ -71,6 +71,7 @@ const BoundInput = struct {
 pub const PinMapping = struct {
     name: []const u8,
     global_id: u32,
+    width: u8,
 };
 
 pub const ProjectTopology = struct {
@@ -110,14 +111,14 @@ pub fn serializeProjectFull(
     errdefer input_ids_list.deinit(allocator);
     for (root_module.inputs) |input| {
         const global_id = root_local_to_global.get(input.component.value) orelse continue;
-        try input_ids_list.append(allocator, .{ .name = input.name, .global_id = global_id });
+        try input_ids_list.append(allocator, .{ .name = input.name, .global_id = global_id, .width = input.width });
     }
 
     var output_ids_list: std.ArrayList(PinMapping) = .{};
     errdefer output_ids_list.deinit(allocator);
     for (root_module.outputs) |output| {
         const global_id = output_map.get(output.name) orelse continue;
-        try output_ids_list.append(allocator, .{ .name = output.name, .global_id = global_id });
+        try output_ids_list.append(allocator, .{ .name = output.name, .global_id = global_id, .width = output.width });
     }
 
     const payload = try encodePayload(allocator, state.components.items, state.connections.items);

--- a/tests/e2e/section_writer_fixtures_test.zig
+++ b/tests/e2e/section_writer_fixtures_test.zig
@@ -284,6 +284,18 @@ const circuit_fixtures = [_]Fixture{
     .{ .root_path = "tests/fixtures/circuits/regression_led_out_drives_gate.circ", .spec_path = "tests/fixtures/expected-wasm/regression_led_out_drives_gate.txt" },
     .{ .root_path = "tests/fixtures/circuits/stress_chain_100.circ", .spec_path = "tests/fixtures/expected-wasm/stress_chain_100.txt" },
     .{ .root_path = "tests/fixtures/circuits/stress_grid_10x10.circ", .spec_path = "tests/fixtures/expected-wasm/stress_grid_10x10.txt" },
+    // Datapath circuits: multi-bit logic decomposed onto width-1 pins, so they
+    // exercise real arithmetic / routing through the artifact without needing
+    // the multi-bit value codec. Expected values come from `--truth-table`.
+    .{ .root_path = "tests/fixtures/circuits/mux_2to1.circ", .spec_path = "tests/fixtures/expected-wasm/mux_2to1.txt" },
+    .{ .root_path = "tests/fixtures/circuits/mux_4bit_2to1.circ", .spec_path = "tests/fixtures/expected-wasm/mux_4bit_2to1.txt" },
+    .{ .root_path = "tests/fixtures/circuits/demux_1to2.circ", .spec_path = "tests/fixtures/expected-wasm/demux_1to2.txt" },
+    .{ .root_path = "tests/fixtures/circuits/demux_4bit_1to2.circ", .spec_path = "tests/fixtures/expected-wasm/demux_4bit_1to2.txt" },
+    .{ .root_path = "tests/fixtures/circuits/four_bit_adder.circ", .spec_path = "tests/fixtures/expected-wasm/four_bit_adder.txt" },
+    .{ .root_path = "tests/fixtures/circuits/five_bit_adder.circ", .spec_path = "tests/fixtures/expected-wasm/five_bit_adder.txt" },
+    .{ .root_path = "tests/fixtures/circuits/six_bit_adder.circ", .spec_path = "tests/fixtures/expected-wasm/six_bit_adder.txt" },
+    .{ .root_path = "tests/fixtures/circuits/eight_bit_adder.circ", .spec_path = "tests/fixtures/expected-wasm/eight_bit_adder.txt" },
+    .{ .root_path = "tests/fixtures/circuits/alu_4bit.circ", .spec_path = "tests/fixtures/expected-wasm/alu_4bit.txt" },
 };
 
 const project_fixtures = [_]Fixture{

--- a/tests/e2e/section_writer_fixtures_test.zig
+++ b/tests/e2e/section_writer_fixtures_test.zig
@@ -15,7 +15,13 @@ const Fixture = struct {
 
 const Assignment = struct {
     name: []const u8,
-    value: i32,
+    /// Raw state token as written, e.g. "1010" or "?". Emitted verbatim on the
+    /// expected-output side, so it must already be in canonical form.
+    text: []const u8,
+    /// MSB-first decoding of `text` into the BitVecState halves: char 0 is the
+    /// high bit. Undefined bits ('?') leave both `value` and `defined` clear.
+    value: u64,
+    defined: u64,
 };
 
 const Step = struct {
@@ -30,12 +36,33 @@ fn hasHardErrors(diags: []const diagnostics.Diagnostic) bool {
     return false;
 }
 
+/// A state token is a per-bit string over {0, 1, ?}, MSB first (char 0 is the
+/// high bit), one character per pin bit. Width-1 pins use a single "0"/"1"/"?";
+/// wider buses use one char per bit (e.g. "1010" is value 10 across 4 bits,
+/// "10?1" marks bit 1 undefined). This replaces the previous decimal encoding
+/// where "2" was the undefined sentinel, which could not represent multi-bit
+/// values or per-bit undefined.
 fn parseAssignment(token: []const u8) !Assignment {
     const eq = std.mem.indexOfScalar(u8, token, '=') orelse return error.InvalidAssignment;
-    return .{
-        .name = token[0..eq],
-        .value = try std.fmt.parseInt(i32, token[eq + 1 ..], 10),
-    };
+    const name = token[0..eq];
+    const text = token[eq + 1 ..];
+    if (text.len == 0 or text.len > 64) return error.InvalidStateToken;
+    var value: u64 = 0;
+    var defined: u64 = 0;
+    for (text, 0..) |c, i| {
+        const bit: u6 = @intCast(text.len - 1 - i);
+        const mask = @as(u64, 1) << bit;
+        switch (c) {
+            '0' => defined |= mask,
+            '1' => {
+                defined |= mask;
+                value |= mask;
+            },
+            '?' => {},
+            else => return error.InvalidStateToken,
+        }
+    }
+    return .{ .name = name, .text = text, .value = value, .defined = defined };
 }
 
 fn parseSide(allocator: std.mem.Allocator, text: []const u8) ![]Assignment {
@@ -66,6 +93,13 @@ fn parseSteps(allocator: std.mem.Allocator, text: []const u8) ![]Step {
 fn pinId(mappings: []const serializer.PinMapping, name: []const u8) ?u32 {
     for (mappings) |m| {
         if (std.mem.eql(u8, m.name, name)) return m.global_id;
+    }
+    return null;
+}
+
+fn pinMapping(mappings: []const serializer.PinMapping, name: []const u8) ?serializer.PinMapping {
+    for (mappings) |m| {
+        if (std.mem.eql(u8, m.name, name)) return m;
     }
     return null;
 }
@@ -202,6 +236,7 @@ fn runFixture(fixture: Fixture, allocator: std.mem.Allocator) !void {
         \\    const ptr = instance.exports.topology_alloc(topoBytes.length);
         \\    new Uint8Array(instance.exports.memory.buffer).set(topoBytes, ptr);
         \\    instance.exports.init();
+        \\    const fmtState = (v, d, w) => { let s = ''; for (let b = w - 1; b >= 0; b--) { const m = 1n << BigInt(b); s += ((d & m) === 0n) ? '?' : (((v & m) === 0n) ? '0' : '1'); } return s; };
         \\
     );
 
@@ -214,25 +249,23 @@ fn runFixture(fixture: Fixture, allocator: std.mem.Allocator) !void {
                 std.debug.print("Unknown input pin '{s}' in fixture {s}\n", .{ inp.name, fixture.root_path });
                 return error.UnknownInputPin;
             };
-            const value: u64 = if (inp.value == 1) 1 else 0;
-            const defined: u64 = if (inp.value == 2) 0 else 1;
-            try w.print("    instance.exports.setPin({d}, {d}n, {d}n);\n", .{ id, value, defined });
+            try w.print("    instance.exports.setPin({d}, {d}n, {d}n);\n", .{ id, inp.value, inp.defined });
         }
         try w.writeAll("    instance.exports.run();\n");
         try w.print("    const p{d} = [];\n", .{idx});
         var first = true;
         for (step.outputs) |out| {
-            const id = pinId(topo.output_ids, out.name) orelse {
+            const mapping = pinMapping(topo.output_ids, out.name) orelse {
                 std.debug.print("Unknown output pin '{s}' in fixture {s}\n", .{ out.name, fixture.root_path });
                 return error.UnknownOutputPin;
             };
             try w.print(
-                "    p{d}.push('{s}=' + ((instance.exports.getOutputDefined({d}) === 0n) ? 2 : (instance.exports.getOutputValue({d}) === 0n ? 0 : 1)));\n",
-                .{ idx, out.name, id, id },
+                "    p{d}.push('{s}=' + fmtState(instance.exports.getOutputValue({d}), instance.exports.getOutputDefined({d}), {d}));\n",
+                .{ idx, out.name, mapping.global_id, mapping.global_id, mapping.width },
             );
             if (!first) try ew.writeAll(" ");
             first = false;
-            try ew.print("{s}={d}", .{ out.name, out.value });
+            try ew.print("{s}={s}", .{ out.name, out.text });
         }
         try w.print("    console.log(p{d}.join(' '));\n", .{idx});
         try ew.writeAll("\n");
@@ -296,6 +329,11 @@ const circuit_fixtures = [_]Fixture{
     .{ .root_path = "tests/fixtures/circuits/six_bit_adder.circ", .spec_path = "tests/fixtures/expected-wasm/six_bit_adder.txt" },
     .{ .root_path = "tests/fixtures/circuits/eight_bit_adder.circ", .spec_path = "tests/fixtures/expected-wasm/eight_bit_adder.txt" },
     .{ .root_path = "tests/fixtures/circuits/alu_4bit.circ", .spec_path = "tests/fixtures/expected-wasm/alu_4bit.txt" },
+    // Codec coverage: slice_basic crosses a multi-bit value in and out;
+    // single_gate carries an undefined ('?') vector. Together they exercise
+    // both new paths in the fixture bit-string codec.
+    .{ .root_path = "tests/fixtures/circuits/slice_basic.circ", .spec_path = "tests/fixtures/expected-wasm/slice_basic.txt" },
+    .{ .root_path = "tests/fixtures/circuits/single_gate.circ", .spec_path = "tests/fixtures/expected-wasm/single_gate.txt" },
 };
 
 const project_fixtures = [_]Fixture{

--- a/tests/e2e/section_writer_fixtures_test.zig
+++ b/tests/e2e/section_writer_fixtures_test.zig
@@ -334,6 +334,20 @@ const circuit_fixtures = [_]Fixture{
     // both new paths in the fixture bit-string codec.
     .{ .root_path = "tests/fixtures/circuits/slice_basic.circ", .spec_path = "tests/fixtures/expected-wasm/slice_basic.txt" },
     .{ .root_path = "tests/fixtures/circuits/single_gate.circ", .spec_path = "tests/fixtures/expected-wasm/single_gate.txt" },
+    // Bus-width circuits across the artifact: slice / concat / bit-index value
+    // lowering, the multi-bit ALU (also parametric macros at width), and the
+    // wide built-in macro expansions. concat_four_bits also drives one bit
+    // undefined to check multi-bit undefined propagation.
+    .{ .root_path = "tests/fixtures/circuits/slice_high_bits.circ", .spec_path = "tests/fixtures/expected-wasm/slice_high_bits.txt" },
+    .{ .root_path = "tests/fixtures/circuits/slice_then_concat.circ", .spec_path = "tests/fixtures/expected-wasm/slice_then_concat.txt" },
+    .{ .root_path = "tests/fixtures/circuits/concat_four_bits.circ", .spec_path = "tests/fixtures/expected-wasm/concat_four_bits.txt" },
+    .{ .root_path = "tests/fixtures/circuits/bit_index_a2.circ", .spec_path = "tests/fixtures/expected-wasm/bit_index_a2.txt" },
+    .{ .root_path = "tests/fixtures/circuits/alu_4bit_multibit.circ", .spec_path = "tests/fixtures/expected-wasm/alu_4bit_multibit.txt" },
+    .{ .root_path = "tests/fixtures/circuits/nand_4bit_macro.circ", .spec_path = "tests/fixtures/expected-wasm/nand_4bit_macro.txt" },
+    .{ .root_path = "tests/fixtures/circuits/or_4bit_macro.circ", .spec_path = "tests/fixtures/expected-wasm/or_4bit_macro.txt" },
+    .{ .root_path = "tests/fixtures/circuits/xnor_4bit_macro.circ", .spec_path = "tests/fixtures/expected-wasm/xnor_4bit_macro.txt" },
+    .{ .root_path = "tests/fixtures/circuits/nor_8bit_macro.circ", .spec_path = "tests/fixtures/expected-wasm/nor_8bit_macro.txt" },
+    .{ .root_path = "tests/fixtures/circuits/xor_8bit_macro.circ", .spec_path = "tests/fixtures/expected-wasm/xor_8bit_macro.txt" },
 };
 
 const project_fixtures = [_]Fixture{

--- a/tests/fixtures/expected-wasm/alu_4bit.txt
+++ b/tests/fixtures/expected-wasm/alu_4bit.txt
@@ -1,0 +1,28 @@
+# Hack ALU (4-bit) driven through the real compiled artifact.
+# Operands are fixed at x=3 (0b0011) and y=5 (0b0101); each vector sets the
+# six control bits (zx nx zy ny f no) for one documented operation and reads
+# the four result bits. Outputs are little-endian: out0 is the LSB.
+# Expected values were taken from `circ-compile alu_4bit.circ --truth-table`.
+
+# out = 0
+zx=1 nx=0 zy=1 ny=0 f=1 no=0 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=0 out1=0 out2=0 out3=0
+# out = 1
+zx=1 nx=1 zy=1 ny=1 f=1 no=1 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=1 out1=0 out2=0 out3=0
+# out = -1 (0b1111)
+zx=1 nx=1 zy=1 ny=0 f=1 no=0 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=1 out1=1 out2=1 out3=1
+# out = x (3)
+zx=0 nx=0 zy=1 ny=1 f=0 no=0 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=1 out1=1 out2=0 out3=0
+# out = y (5)
+zx=1 nx=1 zy=0 ny=0 f=0 no=0 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=1 out1=0 out2=1 out3=0
+# out = !x (0b1100 = 12)
+zx=0 nx=0 zy=1 ny=1 f=0 no=1 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=0 out1=0 out2=1 out3=1
+# out = -x (0b1101 = 13)
+zx=0 nx=0 zy=1 ny=1 f=1 no=1 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=1 out1=0 out2=1 out3=1
+# out = x + y (8)
+zx=0 nx=0 zy=0 ny=0 f=1 no=0 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=0 out1=0 out2=0 out3=1
+# out = x - y (0b1110 = 14)
+zx=0 nx=1 zy=0 ny=0 f=1 no=1 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=0 out1=1 out2=1 out3=1
+# out = x & y (1)
+zx=0 nx=0 zy=0 ny=0 f=0 no=0 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=1 out1=0 out2=0 out3=0
+# out = x | y (0b0111 = 7)
+zx=0 nx=1 zy=0 ny=1 f=0 no=1 x0=1 x1=1 x2=0 x3=0 y0=1 y1=0 y2=1 y3=0 => out0=1 out1=1 out2=1 out3=0

--- a/tests/fixtures/expected-wasm/alu_4bit_multibit.txt
+++ b/tests/fixtures/expected-wasm/alu_4bit_multibit.txt
@@ -1,0 +1,29 @@
+# Multi-bit Hack ALU through the real artifact: x and y are 4-bit buses and
+# out is a 4-bit bus, so each vector drives two multi-bit values across setPin
+# and reads a multi-bit value back. Internally the ALU broadcasts control bits
+# into the lanes and uses the parametric built-in macros at width 4, so this
+# also exercises parametric sub-circuit instantiation through the artifact.
+# Operands fixed at x=3 (0011) and y=5 (0101); values from --truth-table.
+
+# out = 0
+zx=1 nx=0 zy=1 ny=0 f=1 no=0 x=0011 y=0101 => out=0000
+# out = 1
+zx=1 nx=1 zy=1 ny=1 f=1 no=1 x=0011 y=0101 => out=0001
+# out = -1
+zx=1 nx=1 zy=1 ny=0 f=1 no=0 x=0011 y=0101 => out=1111
+# out = x
+zx=0 nx=0 zy=1 ny=1 f=0 no=0 x=0011 y=0101 => out=0011
+# out = y
+zx=1 nx=1 zy=0 ny=0 f=0 no=0 x=0011 y=0101 => out=0101
+# out = !x
+zx=0 nx=0 zy=1 ny=1 f=0 no=1 x=0011 y=0101 => out=1100
+# out = -x
+zx=0 nx=0 zy=1 ny=1 f=1 no=1 x=0011 y=0101 => out=1101
+# out = x + y
+zx=0 nx=0 zy=0 ny=0 f=1 no=0 x=0011 y=0101 => out=1000
+# out = x - y
+zx=0 nx=1 zy=0 ny=0 f=1 no=1 x=0011 y=0101 => out=1110
+# out = x & y
+zx=0 nx=0 zy=0 ny=0 f=0 no=0 x=0011 y=0101 => out=0001
+# out = x | y
+zx=0 nx=1 zy=0 ny=1 f=0 no=1 x=0011 y=0101 => out=0111

--- a/tests/fixtures/expected-wasm/bit_index_a2.txt
+++ b/tests/fixtures/expected-wasm/bit_index_a2.txt
@@ -1,0 +1,6 @@
+# Bit-index through the real artifact: o = a[2], a single bit selected out of
+# a 4-bit input (width-1 output). Verifies bit-index lowering end to end.
+a=0011 => o=0
+a=0100 => o=1
+a=1011 => o=0
+a=1111 => o=1

--- a/tests/fixtures/expected-wasm/concat_four_bits.txt
+++ b/tests/fixtures/expected-wasm/concat_four_bits.txt
@@ -1,0 +1,8 @@
+# Concatenation through the real artifact: o = {a, b, c, d} with a as the LSB.
+# The last vector drives d undefined and checks that the undefined bit
+# propagates to the high bit of the output ('?' in o).
+a=0 b=1 c=1 d=0 => o=0110
+a=0 b=1 c=0 d=1 => o=1010
+a=1 b=1 c=1 d=1 => o=1111
+a=0 b=0 c=0 d=0 => o=0000
+a=1 b=0 c=1 d=? => o=?101

--- a/tests/fixtures/expected-wasm/demux_1to2.txt
+++ b/tests/fixtures/expected-wasm/demux_1to2.txt
@@ -1,0 +1,6 @@
+# 1-to-2 demux through the real artifact: sel picks which output the input
+# is routed to; the other output is held low.
+in=1 sel=0 => out_a=1 out_b=0
+in=1 sel=1 => out_a=0 out_b=1
+in=0 sel=0 => out_a=0 out_b=0
+in=0 sel=1 => out_a=0 out_b=0

--- a/tests/fixtures/expected-wasm/demux_4bit_1to2.txt
+++ b/tests/fixtures/expected-wasm/demux_4bit_1to2.txt
@@ -1,0 +1,4 @@
+# 4-bit 1-to-2 demux through the real artifact. in=10 (0b1010).
+# sel=0 routes in to out_a (out_b held low); sel=1 routes in to out_b.
+in0=0 in1=1 in2=0 in3=1 sel=0 => out_a0=0 out_a1=1 out_a2=0 out_a3=1 out_b0=0 out_b1=0 out_b2=0 out_b3=0
+in0=0 in1=1 in2=0 in3=1 sel=1 => out_a0=0 out_a1=0 out_a2=0 out_a3=0 out_b0=0 out_b1=1 out_b2=0 out_b3=1

--- a/tests/fixtures/expected-wasm/eight_bit_adder.txt
+++ b/tests/fixtures/expected-wasm/eight_bit_adder.txt
@@ -1,0 +1,6 @@
+# 8-bit ripple-carry adder through the real artifact. Sum bits s0..s7
+# little-endian, cout is the carry out of bit 7.
+# 200 + 100 = 300 (carry out; low byte = 44)
+a0=0 a1=0 a2=0 a3=1 a4=0 a5=0 a6=1 a7=1 b0=0 b1=0 b2=1 b3=0 b4=0 b5=1 b6=1 b7=0 => s0=0 s1=0 s2=1 s3=1 s4=0 s5=1 s6=0 s7=0 cout=1
+# 100 + 27 = 127
+a0=0 a1=0 a2=1 a3=0 a4=0 a5=1 a6=1 a7=0 b0=1 b1=1 b2=0 b3=1 b4=1 b5=0 b6=0 b7=0 => s0=1 s1=1 s2=1 s3=1 s4=1 s5=1 s6=1 s7=0 cout=0

--- a/tests/fixtures/expected-wasm/five_bit_adder.txt
+++ b/tests/fixtures/expected-wasm/five_bit_adder.txt
@@ -1,0 +1,6 @@
+# 5-bit ripple-carry adder through the real artifact. Sum bits s0..s4
+# little-endian, cout is the carry out of bit 4.
+# 13 + 7 = 20
+a0=1 a1=0 a2=1 a3=1 a4=0 b0=1 b1=1 b2=1 b3=0 b4=0 => s0=0 s1=0 s2=1 s3=0 s4=1 cout=0
+# 20 + 20 = 40 (carry out)
+a0=0 a1=0 a2=1 a3=0 a4=1 b0=0 b1=0 b2=1 b3=0 b4=1 => s0=0 s1=0 s2=0 s3=1 s4=0 cout=1

--- a/tests/fixtures/expected-wasm/four_bit_adder.txt
+++ b/tests/fixtures/expected-wasm/four_bit_adder.txt
@@ -1,0 +1,14 @@
+# 4-bit ripple-carry adder through the real artifact. a=(a3a2a1a0), b=(b3b2b1b0),
+# sum bits s0..s3 little-endian, cout is the carry out of bit 3.
+# Expected values from `circ-compile four_bit_adder.circ --truth-table`.
+
+# 0 + 0 = 0
+a0=0 a1=0 a2=0 a3=0 b0=0 b1=0 b2=0 b3=0 => s0=0 s1=0 s2=0 s3=0 cout=0
+# 3 + 5 = 8
+a0=1 a1=1 a2=0 a3=0 b0=1 b1=0 b2=1 b3=0 => s0=0 s1=0 s2=0 s3=1 cout=0
+# 6 + 6 = 12
+a0=0 a1=1 a2=1 a3=0 b0=0 b1=1 b2=1 b3=0 => s0=0 s1=0 s2=1 s3=1 cout=0
+# 7 + 9 = 16 (carry out)
+a0=1 a1=1 a2=1 a3=0 b0=1 b1=0 b2=0 b3=1 => s0=0 s1=0 s2=0 s3=0 cout=1
+# 15 + 1 = 16 (carry out)
+a0=1 a1=1 a2=1 a3=1 b0=1 b1=0 b2=0 b3=0 => s0=0 s1=0 s2=0 s3=0 cout=1

--- a/tests/fixtures/expected-wasm/mux_2to1.txt
+++ b/tests/fixtures/expected-wasm/mux_2to1.txt
@@ -1,0 +1,5 @@
+# 2-to-1 mux through the real artifact: sel=0 routes a, sel=1 routes b.
+a=1 b=0 sel=0 => out=1
+a=0 b=1 sel=0 => out=0
+a=1 b=0 sel=1 => out=0
+a=0 b=1 sel=1 => out=1

--- a/tests/fixtures/expected-wasm/mux_4bit_2to1.txt
+++ b/tests/fixtures/expected-wasm/mux_4bit_2to1.txt
@@ -1,0 +1,4 @@
+# 4-bit 2-to-1 mux through the real artifact. a=10 (0b1010), b=5 (0b0101).
+# sel=0 routes a to out, sel=1 routes b. Outputs little-endian.
+a0=0 a1=1 a2=0 a3=1 b0=1 b1=0 b2=1 b3=0 sel=0 => out0=0 out1=1 out2=0 out3=1
+a0=0 a1=1 a2=0 a3=1 b0=1 b1=0 b2=1 b3=0 sel=1 => out0=1 out1=0 out2=1 out3=0

--- a/tests/fixtures/expected-wasm/nand_4bit_macro.txt
+++ b/tests/fixtures/expected-wasm/nand_4bit_macro.txt
@@ -1,0 +1,5 @@
+# 4-bit NAND macro through the real artifact (out = ~(a & b), per bit).
+# Exercises a built-in macro expanded at width 4 across the topology splice.
+a=1100 b=1010 => out=0111
+a=0000 b=1111 => out=1111
+a=1111 b=1111 => out=0000

--- a/tests/fixtures/expected-wasm/nor_8bit_macro.txt
+++ b/tests/fixtures/expected-wasm/nor_8bit_macro.txt
@@ -1,0 +1,5 @@
+# 8-bit NOR macro through the real artifact (out = ~(a | b), per bit).
+# The widest value to cross the artifact in the suite.
+a=11001010 b=01010101 => out=00100000
+a=00000000 b=00000000 => out=11111111
+a=11111111 b=00000000 => out=00000000

--- a/tests/fixtures/expected-wasm/or_4bit_macro.txt
+++ b/tests/fixtures/expected-wasm/or_4bit_macro.txt
@@ -1,0 +1,4 @@
+# 4-bit OR macro through the real artifact (out = a | b, per bit).
+a=1100 b=1010 => out=1110
+a=0000 b=0000 => out=0000
+a=1010 b=0101 => out=1111

--- a/tests/fixtures/expected-wasm/single_gate.txt
+++ b/tests/fixtures/expected-wasm/single_gate.txt
@@ -1,0 +1,6 @@
+# Width-1 NOT gate, including an undefined vector. NOT of an undefined input
+# stays undefined: the engine flips defined bits and leaves undefined bits
+# alone. '?' is the undefined state token.
+a=0 => out=1
+a=1 => out=0
+a=? => out=?

--- a/tests/fixtures/expected-wasm/six_bit_adder.txt
+++ b/tests/fixtures/expected-wasm/six_bit_adder.txt
@@ -1,0 +1,6 @@
+# 6-bit ripple-carry adder through the real artifact. Sum bits s0..s5
+# little-endian, cout is the carry out of bit 5.
+# 40 + 30 = 70 (carry out)
+a0=0 a1=0 a2=0 a3=1 a4=0 a5=1 b0=0 b1=1 b2=1 b3=1 b4=1 b5=0 => s0=0 s1=1 s2=1 s3=0 s4=0 s5=0 cout=1
+# 10 + 20 = 30
+a0=0 a1=1 a2=0 a3=1 a4=0 a5=0 b0=0 b1=0 b2=1 b3=0 b4=1 b5=0 => s0=0 s1=1 s2=1 s3=1 s4=1 s5=0 cout=0

--- a/tests/fixtures/expected-wasm/slice_basic.txt
+++ b/tests/fixtures/expected-wasm/slice_basic.txt
@@ -1,0 +1,8 @@
+# Slice through the real artifact: o = a[0..2], the low two bits of a 4-bit
+# input. This drives a multi-bit value across setPin and reads a multi-bit
+# value back, exercising the bit-string codec end to end. State tokens are
+# MSB-first (the leftmost character is the high bit).
+a=1010 => o=10
+a=0111 => o=11
+a=0100 => o=00
+a=0001 => o=01

--- a/tests/fixtures/expected-wasm/slice_high_bits.txt
+++ b/tests/fixtures/expected-wasm/slice_high_bits.txt
@@ -1,0 +1,6 @@
+# Slice through the real artifact: o = a[2..4], the high two bits of a 4-bit
+# input. Tokens are MSB-first.
+a=1010 => o=10
+a=1100 => o=11
+a=0111 => o=01
+a=0011 => o=00

--- a/tests/fixtures/expected-wasm/slice_then_concat.txt
+++ b/tests/fixtures/expected-wasm/slice_then_concat.txt
@@ -1,0 +1,7 @@
+# Slice-then-concat through the real artifact: o = {a[0..2], a[2..4]}, which
+# splits the 4-bit input into halves and rejoins them, reconstituting a.
+# Verifies a slice feeding a concat survives the topology round-trip.
+a=1010 => o=1010
+a=0110 => o=0110
+a=1111 => o=1111
+a=0001 => o=0001

--- a/tests/fixtures/expected-wasm/xnor_4bit_macro.txt
+++ b/tests/fixtures/expected-wasm/xnor_4bit_macro.txt
@@ -1,0 +1,4 @@
+# 4-bit XNOR macro through the real artifact (out = ~(a ^ b), per bit).
+a=1100 b=1010 => out=1001
+a=1111 b=1111 => out=1111
+a=1010 b=0101 => out=0000

--- a/tests/fixtures/expected-wasm/xor_8bit_macro.txt
+++ b/tests/fixtures/expected-wasm/xor_8bit_macro.txt
@@ -1,0 +1,4 @@
+# 8-bit XOR macro through the real artifact (out = a ^ b, per bit).
+a=11001010 b=01010101 => out=10011111
+a=11111111 b=00000000 => out=11111111
+a=10101010 b=10101010 => out=00000000


### PR DESCRIPTION
The `section_writer` fixtures are the only tests that drive the genuine compiled `.wasm` end to end (topology serialize, section splice, instantiate, then `setPin`/`run`/`getOutput`). Until now they ran only trivial width-1, fully-defined circuits, so multi-bit values, undefined signals, and real datapaths were exercised only on the native engine via truth-table goldens, never across the artifact boundary.

### Harness
- Replace the fixture state token with a per-bit `{0, 1, ?}` string, MSB first, one character per pin bit, so the harness can drive and read multi-bit and undefined states. This needs the pin width at drive/render time, so `PinMapping` now carries it (read from the `InputPin`/`OutputPin` IR nodes).

### Coverage added through the real artifact
- **Datapaths on width-1 pins:** the Hack 4-bit ALU, 4/5/6/8-bit ripple-carry adders, and 2-to-1 / 4-bit muxes and demuxes.
- **Bus-width circuits:** slice, concat, and bit-index value lowering; the 4-bit-bus ALU (which also instantiates the parametric built-in macros at width); and the wide NAND/OR/XNOR (4-bit) and NOR/XOR (8-bit) macro expansions.
- **Undefined:** a width-1 NOT of an undefined input, and a partial-undefined concat operand.

Expected values are taken from `circ-compile --truth-table`, so a fixture divergence localizes to an artifact-only stage (serialization, the section splice, or BigInt marshaling) rather than to engine logic, which the truth-table goldens already cover.

Not covered here: stateful/feedback circuits and a dedicated parametric sub-circuit caller; both can follow separately.
