### PR TITLE
feat(sim): --sim stdio drive protocol for circuit testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ There is no `-Dtest-filter` flag wired into `build.zig`. To run a single test mo
 
 ## CLI shape
 
-`circ-compile` has five mutually exclusive modes (dispatch lives in `cmd/circ-compile/main.zig`'s `run()`), plus a sixth `--analyze` surface intercepted earlier in `main()` that takes a JSON request on stdin rather than a file path. Only the default mode writes a `.wasm`:
+`circ-compile` has six mutually exclusive modes (dispatch lives in `cmd/circ-compile/main.zig`'s `run()`), plus a seventh `--analyze` surface intercepted earlier in `main()` that takes a JSON request on stdin rather than a file path. Only the default mode writes a `.wasm`:
 
 | Invocation | Output |
 | --- | --- |
@@ -44,6 +44,7 @@ There is no `-Dtest-filter` flag wired into `build.zig`. To run a single test mo
 | `circ-compile in.circ --inspect` | Pretty-printed parse tree, resolved IR, diagnostics. |
 | `circ-compile in.circ --preview` | ASCII schematic of the resolved circuit. |
 | `circ-compile in.circ --truth-table` | Enumerated truth table. Pair with `--format=markdown\|csv\|json`. |
+| `circ-compile in.circ --sim` | Interactive stdio drive protocol (proto=1): drive the circuit by pin name for testing/tooling; see `DOCS/sim-protocol.md`. |
 | `echo '<json>' \| circ-compile --analyze` | JSON analysis (files, diagnostics, symbols, references) on stdout for editor tooling; see `DOCS/analyze-api.md`. |
 
 Hard errors block emission; partial or "best-effort" artifacts are never produced. `--warnings-as-errors` (alias `-Werror`) promotes warnings.

--- a/DOCS/index.md
+++ b/DOCS/index.md
@@ -23,6 +23,7 @@ output out(in=inv.out)
 | [simulation-engine.md](simulation-engine.md) | Zig API reference for `lib/circuit.zig`: types, propagation, gate logic |
 | [wasm-api.md](wasm-api.md)                   | Runtime API exposed by the compiled `.wasm`: imports, exports, sections |
 | [analyze-api.md](analyze-api.md)             | `circ-compile --analyze` JSON contract for editor tooling (the circ-lsp server) |
+| [sim-protocol.md](sim-protocol.md)           | `circ-compile --sim` stdio drive protocol for testing and tooling               |
 | [circuit-format.md](circuit-format.md)       | `.circ` DSL syntax, grammar, file examples                              |
 | [preview.md](preview.md)                     | `circ-compile --preview`: ASCII circuit schematic rendering             |
 | [benchmark.md](benchmark.md)                 | `zig build bench`: engine regression gate, counters, golden workflow    |

--- a/DOCS/sim-protocol.md
+++ b/DOCS/sim-protocol.md
@@ -1,0 +1,104 @@
+# `--sim` drive protocol (proto=1)
+
+`circ-compile <input>.circ --sim` compiles the circuit, then serves a small
+line-oriented request/response protocol over stdin/stdout. It lets an external
+process (a test runner, a REPL, an editor) drive the circuit by pin name:
+set inputs, settle, read outputs. It writes no file.
+
+The mode runs the same native simulation engine as `--truth-table`, built from
+the same resolved topology, so behavior matches the compiled `.wasm`. In fact
+each command maps 1:1 onto the artifact's WASM exports (see
+[`wasm-api.md`](wasm-api.md)): `set` → `setPin`, `run` → `run`,
+`get` → `getOutputValue`/`getOutputDefined`.
+
+## Transport and framing
+
+- Line-oriented and synchronous: write one command per line to stdin; the
+  process replies before you send the next.
+- A reply is either a **status line** (`ok ...` / `err <CODE> <message>`) or a
+  **counted block**: a header line ending in a count, followed by exactly that
+  many record lines.
+- Blank lines and lines starting with `#` are ignored and produce no reply
+  (so a session can be driven by hand or from a script).
+- EOF on stdin, or `quit`, shuts the process down.
+
+## Handshake
+
+The first output line is the handshake. On a circuit that compiles, with one
+`pin` record per top-level pin and one `diag` line per warning:
+
+```
+ready proto=1 pins=3 warnings=0
+pin a in 1
+pin b in 1
+pin out out 1
+```
+
+`pin <name> <in|out> <width>`. On a circuit with hard errors there is no session
+to drive; the process emits the diagnostics and exits nonzero:
+
+```
+error diags=1
+diag error E004 in.circ:3:1 required input 'b' is unconnected
+```
+
+`diag <error|warning> <CODE> <file>:<line>:<col> <message>`, reusing the stable
+validator codes (`E001`-`E016`, `W001`-`W003`).
+
+## Value and width encoding
+
+| Aspect | Rule |
+| --- | --- |
+| Input literals | Decimal `12`, hex `0x0c`, binary `0b1100`, octal `0o14` (`_` separators ok). |
+| Output literals | Lowercase hex, `0x`-prefixed (`0x0`, `0x1f`). |
+| Value + mask | Every signal is a `(value, mask)` pair; mask bit 1 = defined, mask bit 0 = undefined (X). |
+| Default mask | An omitted mask means fully defined (all bits of the pin's width). |
+| Undefined bits | Value bits where the mask is 0 are emitted as 0, matching the engine's `BitVecState` equality. |
+| Width | 1 to 64. A literal with bits set beyond the pin's width is an error (`E_WIDTH`), not silently masked. |
+
+## Commands
+
+| Command | Reply | Notes |
+| --- | --- | --- |
+| `pins` | `pins <N>` block + `pin` lines | Re-query of the handshake pin table. |
+| `set <pin> <value> [<mask>]` | `ok` / `err` | Drives a top-level input and settles. `set a 0 0` is fully undefined; `set bus 0x5 0xf` is per-bit. |
+| `get <pin>` | `ok <value> <mask>` / `err` | Reads current state (inputs or outputs). |
+| `dump <in\|out\|all>` | `vals <N>` block + `<name> <value> <mask>` lines | Whole-vector read for snapshots. |
+| `run` | `ok` | Drains the event queue. Redundant after `set` (which already settles); kept for 1:1 parity with the artifact's `run()`. |
+| `eval <assign...> => <query...>` | `ok <name>=<value>/<mask> ...` / `err` | One-shot vector: `pin=value[/mask]` assignments, then the queried pins. Operates on current state (no implicit reset). |
+| `reset` | `ok` | Rebuilds the circuit to its post-`init` state (all pins undefined). Per-scenario isolation without respawning. |
+| `quit` | `ok bye` then exit | EOF on stdin does the same. |
+
+**Error codes** (`err <CODE> <message>`): `E_PROTO` (unknown/malformed command),
+`E_NOPIN` (no such pin), `E_NOTIN` (`set` target is not a top-level input),
+`E_WIDTH` (bits beyond the pin width), `E_BADVAL` (not a valid integer literal).
+
+## Settle model
+
+`set` drives an input and settles the circuit in one step, exactly as the
+shipped artifact's `setPin` does (the native engine's `propagateEvent` enqueues
+and then drains to quiescence). There is no clock to pump: a single `set`
+settles any combinational cascade. For sequential circuits, state persists
+across commands, so a scenario is just `set`/`get` repeated; only `reset`
+clears it. Because each `set` settles independently, an `eval`'s assignments are
+applied in order, each settling, before its queries are read.
+
+## Example session
+
+```
+$ circ-compile and_gate.circ --sim
+ready proto=1 pins=3 warnings=0
+pin a in 1
+pin b in 1
+pin out out 1
+set a 1
+ok
+set b 1
+ok
+get out
+ok 0x1 0x1
+eval a=1 b=0 => out
+ok out=0x0/0x1
+quit
+ok bye
+```

--- a/build.zig
+++ b/build.zig
@@ -1171,6 +1171,22 @@ pub fn build(b: *std.Build) void {
     const run_preview_dump_tests = b.addRunArtifact(preview_dump_tests);
     test_step.dependOn(&run_preview_dump_tests.step);
 
+    // Shared engine session: builds a live engine.Circuit from a full topology
+    // and resolves root pins by name. Consumed by the truth-table builder and
+    // the --sim drive loop.
+    const engine_session_mod = b.createModule(.{
+        .root_source_file = b.path("lib/engine_session.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    engine_session_mod.addImport("circuit", circuit_mod);
+    engine_session_mod.addImport("full_format", topology_full_format_mod);
+    const engine_session_tests = b.addTest(.{
+        .root_module = engine_session_mod,
+    });
+    const run_engine_session_tests = b.addRunArtifact(engine_session_tests);
+    test_step.dependOn(&run_engine_session_tests.step);
+
     // Truth-table mode: enumerates input vectors against a native engine.Circuit
     // built from the full topology, then renders to Markdown.
     const truth_table_builder_mod = b.createModule(.{
@@ -1180,6 +1196,7 @@ pub fn build(b: *std.Build) void {
     });
     truth_table_builder_mod.addImport("circuit", circuit_mod);
     truth_table_builder_mod.addImport("full_format", topology_full_format_mod);
+    truth_table_builder_mod.addImport("engine_session", engine_session_mod);
     circ_compile_mod.addImport("truth_table_builder", truth_table_builder_mod);
     const truth_table_builder_tests = b.addTest(.{
         .root_module = truth_table_builder_mod,

--- a/build.zig
+++ b/build.zig
@@ -1187,6 +1187,37 @@ pub fn build(b: *std.Build) void {
     const run_engine_session_tests = b.addRunArtifact(engine_session_tests);
     test_step.dependOn(&run_engine_session_tests.step);
 
+    // --sim drive protocol: a pure line-protocol codec (no I/O).
+    const sim_protocol_mod = b.createModule(.{
+        .root_source_file = b.path("lib/sim/protocol.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const sim_protocol_tests = b.addTest(.{
+        .root_module = sim_protocol_mod,
+    });
+    const run_sim_protocol_tests = b.addRunArtifact(sim_protocol_tests);
+    test_step.dependOn(&run_sim_protocol_tests.step);
+
+    // --sim drive loop: builds the circuit via engine_session and serves the
+    // request/response protocol against it (set/get/run/eval/dump/reset).
+    const sim_loop_mod = b.createModule(.{
+        .root_source_file = b.path("lib/sim/loop.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    sim_loop_mod.addImport("protocol", sim_protocol_mod);
+    sim_loop_mod.addImport("engine_session", engine_session_mod);
+    sim_loop_mod.addImport("circuit", circuit_mod);
+    sim_loop_mod.addImport("full_format", topology_full_format_mod);
+    sim_loop_mod.addImport("diagnostics", validator_diagnostics_mod);
+    circ_compile_mod.addImport("sim_loop", sim_loop_mod);
+    const sim_loop_tests = b.addTest(.{
+        .root_module = sim_loop_mod,
+    });
+    const run_sim_loop_tests = b.addRunArtifact(sim_loop_tests);
+    test_step.dependOn(&run_sim_loop_tests.step);
+
     // Truth-table mode: enumerates input vectors against a native engine.Circuit
     // built from the full topology, then renders to Markdown.
     const truth_table_builder_mod = b.createModule(.{

--- a/cmd/circ-compile/main.zig
+++ b/cmd/circ-compile/main.zig
@@ -48,6 +48,7 @@ const truth_table_markdown = @import("truth_table_markdown");
 const truth_table_csv = @import("truth_table_csv");
 const truth_table_json = @import("truth_table_json");
 const analyzer = @import("analyze");
+const sim_loop = @import("sim_loop");
 const build_info = @import("build_info");
 
 fn makePathAny(path: []const u8) !void {
@@ -206,7 +207,7 @@ pub fn run(
     // scan_imports' implicit_builtin path. Compile/emit_zig keep the cheaper
     // has_imports gate to avoid the extra disk I/O on macro-free fixtures (locked
     // by perf-budget tests).
-    const needs_project_resolution = args.mode != .inspect and (has_imports or args.mode == .preview or args.mode == .truth_table);
+    const needs_project_resolution = args.mode != .inspect and (has_imports or args.mode == .preview or args.mode == .truth_table or args.mode == .sim);
 
     if (needs_project_resolution) {
         const scan_result = scan_imports.scanProjectImports(allocator, args.input_path) catch |err| {
@@ -269,6 +270,34 @@ pub fn run(
         try stdout_writer.writeAll("\n=== Summary ===\n");
         try stdout_writer.print("{d} errors, {d} warnings\n", .{ counts.errors, counts.warnings });
         return if (counts.errors > 0) 1 else 0;
+    }
+
+    // --sim emits its diagnostics inside the protocol handshake (as `error`/
+    // `diag` lines on stdout), so it intercepts here before the generic
+    // human-readable stderr dump below.
+    if (args.mode == .sim) {
+        if (counts.errors > 0) {
+            try sim_loop.serveError(stdout_writer, args.input_path, diagnostic_list.items);
+            return 1;
+        }
+        var topology = if (maybe_project) |*project|
+            full_serializer.buildFromProject(allocator, project) catch |err| {
+                try stderr_writer.print("topology build failed: {s}\n", .{@errorName(err)});
+                return 1;
+            }
+        else
+            full_serializer.buildFromModule(allocator, &ir_module) catch |err| {
+                try stderr_writer.print("topology build failed: {s}\n", .{@errorName(err)});
+                return 1;
+            };
+        defer topology.deinit(allocator);
+
+        const stdin_reader = std.fs.File.stdin().deprecatedReader();
+        sim_loop.serve(allocator, topology, args.input_path, diagnostic_list.items, stdin_reader, stdout_writer) catch |err| {
+            try stderr_writer.print("sim: {s}\n", .{@errorName(err)});
+            return 1;
+        };
+        return 0;
     }
 
     _ = try printDiagnosticSet(allocator, stderr_writer, args.input_path, diagnostic_list.items);
@@ -352,6 +381,7 @@ pub fn run(
             return 0;
         },
         .inspect => unreachable,
+        .sim => unreachable,
         .preview => {
             var topology = if (maybe_project) |*project|
                 full_serializer.buildFromProject(allocator, project) catch |err| {

--- a/lib/cli/args.zig
+++ b/lib/cli/args.zig
@@ -7,6 +7,7 @@ pub const Mode = enum {
     inspect,
     preview,
     truth_table,
+    sim,
 };
 
 pub const ColorMode = render_color.ColorMode;
@@ -76,6 +77,7 @@ pub const help_text =
     \\    --inspect         Print parse tree, resolved IR, and diagnostics to stdout.
     \\    --preview         Render an ASCII schematic of the circuit to stdout.
     \\    --truth-table     Enumerate every input vector and print a truth table to stdout.
+    \\    --sim             Drive the circuit over a stdio line protocol (proto=1; see DOCS/sim-protocol.md).
     \\
     \\OPTIONS:
     \\    -o <path>                       Output file. Required by compile and --emit-zig modes.
@@ -140,33 +142,40 @@ pub fn parse(argv: []const []const u8) ParseError!Args {
     var seen_inspect = false;
     var seen_preview = false;
     var seen_truth_table = false;
+    var seen_sim = false;
 
     var i: usize = if (argv.len > 0) 1 else 0;
     while (i < argv.len) : (i += 1) {
         const token = argv[i];
 
         if (std.mem.eql(u8, token, "--emit-zig")) {
-            if (seen_inspect or seen_preview or seen_truth_table) return error.ConflictingModes;
+            if (seen_inspect or seen_preview or seen_truth_table or seen_sim) return error.ConflictingModes;
             seen_emit_zig = true;
             args.mode = .emit_zig;
             continue;
         }
         if (std.mem.eql(u8, token, "--inspect")) {
-            if (seen_emit_zig or seen_preview or seen_truth_table) return error.ConflictingModes;
+            if (seen_emit_zig or seen_preview or seen_truth_table or seen_sim) return error.ConflictingModes;
             seen_inspect = true;
             args.mode = .inspect;
             continue;
         }
         if (std.mem.eql(u8, token, "--preview")) {
-            if (seen_emit_zig or seen_inspect or seen_truth_table) return error.ConflictingModes;
+            if (seen_emit_zig or seen_inspect or seen_truth_table or seen_sim) return error.ConflictingModes;
             seen_preview = true;
             args.mode = .preview;
             continue;
         }
         if (std.mem.eql(u8, token, "--truth-table")) {
-            if (seen_emit_zig or seen_inspect or seen_preview) return error.ConflictingModes;
+            if (seen_emit_zig or seen_inspect or seen_preview or seen_sim) return error.ConflictingModes;
             seen_truth_table = true;
             args.mode = .truth_table;
+            continue;
+        }
+        if (std.mem.eql(u8, token, "--sim")) {
+            if (seen_emit_zig or seen_inspect or seen_preview or seen_truth_table) return error.ConflictingModes;
+            seen_sim = true;
+            args.mode = .sim;
             continue;
         }
         if (std.mem.eql(u8, token, "--warnings-as-errors") or std.mem.eql(u8, token, "-Werror")) {
@@ -254,9 +263,10 @@ pub fn parse(argv: []const []const u8) ParseError!Args {
     }
 
     if (!have_input) return error.MissingInput;
-    if (args.mode != .inspect and args.mode != .preview and args.mode != .truth_table and args.output_path == null) return error.MissingOutput;
+    if (args.mode != .inspect and args.mode != .preview and args.mode != .truth_table and args.mode != .sim and args.output_path == null) return error.MissingOutput;
     if (args.mode == .preview and args.output_path != null) return error.InvalidFlagValue;
     if (args.mode == .truth_table and args.output_path != null) return error.InvalidFlagValue;
+    if (args.mode == .sim and args.output_path != null) return error.InvalidFlagValue;
     if (args.expand_macros and args.mode != .preview) return error.InvalidFlagValue;
     if (args.expand_display and args.mode != .preview) return error.InvalidFlagValue;
     if (args.truth_table_format != .markdown and args.mode != .truth_table) return error.InvalidFlagValue;
@@ -487,7 +497,7 @@ test "cli_args_help_text_mentions_every_mode_and_flag" {
         "-o",           "--help",        "-h",                 "--warnings-as-errors",
         "-Werror",      "--expand-macros", "--color=",        "--format=",
         "--strict",     "--verbose",      "--truth-table-format=", "--truth-table-cap=",
-        "--version",
+        "--version",    "--sim",
     };
     inline for (needles) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, help_text, needle) != null);
@@ -563,4 +573,20 @@ test "cli_args_cap_rejects_outside_truth_table" {
         error.InvalidFlagValue,
         parse(&.{ "circ-compile", "in.circ", "--preview", "--truth-table-cap=20" }),
     );
+}
+
+test "cli_args_parse_sim_flag" {
+    const parsed = try parse(&.{ "circ-compile", "in.circ", "--sim" });
+    try std.testing.expectEqual(Mode.sim, parsed.mode);
+    try std.testing.expect(parsed.output_path == null);
+    try std.testing.expectEqualStrings("in.circ", parsed.input_path);
+}
+
+test "cli_args_sim_rejects_output_path" {
+    try std.testing.expectError(error.InvalidFlagValue, parse(&.{ "circ-compile", "in.circ", "--sim", "-o", "out.txt" }));
+}
+
+test "cli_args_sim_rejects_other_modes" {
+    try std.testing.expectError(error.ConflictingModes, parse(&.{ "circ-compile", "in.circ", "--sim", "--truth-table" }));
+    try std.testing.expectError(error.ConflictingModes, parse(&.{ "circ-compile", "in.circ", "--inspect", "--sim" }));
 }

--- a/lib/engine_session.zig
+++ b/lib/engine_session.zig
@@ -1,0 +1,199 @@
+const std = @import("std");
+const engine = @import("circuit");
+const full_format = @import("full_format");
+
+/// A pin on the root circuit, addressable by its source name. `component_id`
+/// is the topology id of the underlying `input_pin`/`output_pin` primitive;
+/// `nodeById` maps it to the live engine node.
+pub const PinRef = struct {
+    name: []const u8,
+    component_id: u32,
+    width: u8,
+};
+
+pub const SessionError = error{
+    OutOfMemory,
+    InvalidTopology,
+};
+
+/// A live `engine.Circuit` built from a `FullTopology`, with its root-level
+/// input and output pins resolved by name. The truth-table builder enumerates
+/// `inputs` exhaustively; `--sim` drives author-supplied vectors against the
+/// same construction. Macro-expanded sub-pins (non-empty `origin`) are wired
+/// through but are not independently addressable, matching the truth table.
+///
+/// The caller owns the `engine.Circuit` so it is never moved after its nodes
+/// are created; `build` only populates it. `inputs`, `outputs`, and the id→node
+/// map are allocated from the caller-supplied allocator.
+pub const Session = struct {
+    circuit: *engine.Circuit,
+    inputs: []const PinRef,
+    outputs: []const PinRef,
+    id_to_node: std.AutoHashMap(u32, *engine.Component),
+
+    pub fn build(
+        alloc: std.mem.Allocator,
+        circuit: *engine.Circuit,
+        topology: full_format.FullTopology,
+    ) SessionError!Session {
+        var input_count: usize = 0;
+        var output_count: usize = 0;
+        for (topology.components) |comp| {
+            if (comp.origin.len != 0) continue;
+            switch (comp.kind) {
+                .input_pin => input_count += 1,
+                .output_pin => output_count += 1,
+                else => {},
+            }
+        }
+
+        const inputs = try alloc.alloc(PinRef, input_count);
+        const outputs = try alloc.alloc(PinRef, output_count);
+        var i_idx: usize = 0;
+        var o_idx: usize = 0;
+        for (topology.components) |comp| {
+            if (comp.origin.len != 0) continue;
+            switch (comp.kind) {
+                .input_pin => {
+                    inputs[i_idx] = .{ .name = comp.name, .component_id = comp.id, .width = comp.width };
+                    i_idx += 1;
+                },
+                .output_pin => {
+                    outputs[o_idx] = .{ .name = comp.name, .component_id = comp.id, .width = comp.width };
+                    o_idx += 1;
+                },
+                else => {},
+            }
+        }
+
+        var id_to_node = std.AutoHashMap(u32, *engine.Component).init(alloc);
+        try id_to_node.ensureTotalCapacity(@intCast(topology.components.len));
+        for (topology.components) |comp| {
+            const node = switch (comp.kind) {
+                .input_pin => circuit.createComponent(.{ .input_pin_gate = .{} }, comp.width),
+                .not_gate => circuit.createComponent(.{ .not_gate = .{} }, comp.width),
+                .and_gate => circuit.createComponent(.{ .and_gate = .{} }, comp.width),
+                .wire => circuit.createComponent(.{ .wire = .{} }, comp.width),
+                .led => circuit.createComponent(.{ .led = .{} }, comp.width),
+                .output_pin => circuit.createComponent(.{ .output_pin = .{} }, comp.width),
+                .slice => blk: {
+                    const aux = switch (comp.aux) {
+                        .slice => |s| s,
+                        else => return error.InvalidTopology,
+                    };
+                    break :blk circuit.createComponent(
+                        .{ .slice = .{ .lo = aux.lo, .hi = aux.hi } },
+                        comp.width,
+                    );
+                },
+                .concat => circuit.createComponent(.{ .concat = .{} }, comp.width),
+            } catch return error.InvalidTopology;
+            node.id = comp.id;
+            id_to_node.putAssumeCapacity(comp.id, node);
+        }
+
+        for (topology.connections) |conn| {
+            const from_node = id_to_node.get(conn.from_id) orelse return error.InvalidTopology;
+            const to_node = id_to_node.get(conn.to_id) orelse return error.InvalidTopology;
+            // Concat destinations interpret the port byte as an operand index,
+            // not a `PortName`; format it back into the `operand_<N>` string the
+            // engine's `connect()` expects.
+            if (to_node.kind == .concat) {
+                var port_buf: [16]u8 = undefined;
+                const port_str = std.fmt.bufPrint(&port_buf, "operand_{d}", .{conn.port}) catch return error.InvalidTopology;
+                circuit.connect(.{ from_node, "out" }, .{ to_node, port_str }) catch return error.InvalidTopology;
+            } else {
+                const port_str = portByteToName(conn.port) catch return error.InvalidTopology;
+                circuit.connect(.{ from_node, "out" }, .{ to_node, port_str }) catch return error.InvalidTopology;
+            }
+        }
+
+        return .{
+            .circuit = circuit,
+            .inputs = inputs,
+            .outputs = outputs,
+            .id_to_node = id_to_node,
+        };
+    }
+
+    pub fn nodeById(self: *const Session, id: u32) ?*engine.Component {
+        return self.id_to_node.get(id);
+    }
+
+    pub fn findInput(self: *const Session, name: []const u8) ?PinRef {
+        for (self.inputs) |pin| {
+            if (std.mem.eql(u8, pin.name, name)) return pin;
+        }
+        return null;
+    }
+
+    pub fn findOutput(self: *const Session, name: []const u8) ?PinRef {
+        for (self.outputs) |pin| {
+            if (std.mem.eql(u8, pin.name, name)) return pin;
+        }
+        return null;
+    }
+};
+
+fn portByteToName(port: u8) ![]const u8 {
+    const port_name = std.meta.intToEnum(full_format.PortName, port) catch return error.InvalidTopology;
+    return switch (port_name) {
+        .in => "in",
+        .a => "a",
+        .b => "b",
+        .out => "out",
+    };
+}
+
+// ---------- Tests ----------
+
+const test_alloc = std.testing.allocator;
+const FullComponentRecord = full_format.FullComponentRecord;
+const FullConnectionRecord = full_format.FullConnectionRecord;
+
+// a (id=0) → and.a, b (id=1) → and.b, and(id=2) → out(id=3, output_pin)
+const and_components = [_]FullComponentRecord{
+    .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+    .{ .id = 1, .kind = .input_pin, .width = 1, .name = "b", .origin = &.{} },
+    .{ .id = 2, .kind = .and_gate, .width = 1, .name = "g", .origin = &.{} },
+    .{ .id = 3, .kind = .output_pin, .width = 1, .name = "out", .origin = &.{} },
+};
+const and_connections = [_]FullConnectionRecord{
+    .{ .from_id = 0, .to_id = 2, .port = @intFromEnum(full_format.PortName.a) },
+    .{ .from_id = 1, .to_id = 2, .port = @intFromEnum(full_format.PortName.b) },
+    .{ .from_id = 2, .to_id = 3, .port = @intFromEnum(full_format.PortName.in) },
+};
+
+test "session resolves root pins by name" {
+    var arena = std.heap.ArenaAllocator.init(test_alloc);
+    defer arena.deinit();
+    var circuit = try engine.Circuit.init();
+    defer circuit.deinit();
+    var session = try Session.build(arena.allocator(), &circuit, .{ .components = &and_components, .connections = &and_connections });
+
+    try std.testing.expectEqual(@as(usize, 2), session.inputs.len);
+    try std.testing.expectEqual(@as(usize, 1), session.outputs.len);
+    try std.testing.expect(session.findInput("a") != null);
+    try std.testing.expect(session.findInput("b") != null);
+    try std.testing.expect(session.findInput("missing") == null);
+    const out = session.findOutput("out").?;
+    try std.testing.expect(session.nodeById(out.component_id) != null);
+}
+
+test "session drives and reads through the engine" {
+    var arena = std.heap.ArenaAllocator.init(test_alloc);
+    defer arena.deinit();
+    var circuit = try engine.Circuit.init();
+    defer circuit.deinit();
+    var session = try Session.build(arena.allocator(), &circuit, .{ .components = &and_components, .connections = &and_connections });
+
+    const a = session.findInput("a").?;
+    const b = session.findInput("b").?;
+    const out = session.findOutput("out").?;
+    try circuit.propagateEvent(session.nodeById(a.component_id).?, .{ .value = 1, .defined = 1, .width = 1 });
+    try circuit.propagateEvent(session.nodeById(b.component_id).?, .{ .value = 1, .defined = 1, .width = 1 });
+
+    const s = circuit.readState(session.nodeById(out.component_id).?.state_handle);
+    try std.testing.expectEqual(@as(u64, 1), s.value);
+    try std.testing.expectEqual(@as(u64, 1), s.defined);
+}

--- a/lib/sim/loop.zig
+++ b/lib/sim/loop.zig
@@ -1,0 +1,327 @@
+const std = @import("std");
+const protocol = @import("protocol");
+const engine_session = @import("engine_session");
+const engine = @import("circuit");
+const full_format = @import("full_format");
+const diagnostics = @import("diagnostics");
+
+const Diagnostic = diagnostics.Diagnostic;
+
+/// Wire-format version. Bump only on a breaking change to the command set,
+/// the value encoding, or the framing (see DOCS/sim-protocol.md).
+pub const PROTO_VERSION: u32 = 1;
+
+const MAX_LINE = 8192;
+
+fn widthMask(width: u8) u64 {
+    if (width >= 64) return std.math.maxInt(u64);
+    return (@as(u64, 1) << @intCast(width)) - 1;
+}
+
+fn writeErr(writer: anytype, code: protocol.ErrorCode, msg: []const u8) !void {
+    try writer.print("err {s} {s}\n", .{ code.tag(), msg });
+}
+
+fn writeDiag(writer: anytype, file_path: []const u8, d: Diagnostic) !void {
+    const sev = switch (d.level) {
+        .err => "error",
+        .warning => "warning",
+    };
+    try writer.print("diag {s} {s} {s}:{d}:{d} {s}\n", .{
+        sev,           @tagName(d.code), file_path,
+        d.span.start_line, d.span.start_col, d.message,
+    });
+}
+
+fn writePinList(writer: anytype, session: *const engine_session.Session) !void {
+    for (session.inputs) |pin| try writer.print("pin {s} in {d}\n", .{ pin.name, pin.width });
+    for (session.outputs) |pin| try writer.print("pin {s} out {d}\n", .{ pin.name, pin.width });
+}
+
+/// `ok <value> <defined>` style read: undefined bits and bits beyond the pin
+/// width are emitted as 0, matching the engine's BitVecState equality rule.
+fn readPin(session: *const engine_session.Session, pin: engine_session.PinRef) struct { value: u64, defined: u64 } {
+    const node = session.nodeById(pin.component_id).?;
+    const s = session.circuit.readState(node.state_handle);
+    const mask = widthMask(pin.width);
+    const defined = s.defined & mask;
+    return .{ .value = s.value & defined, .defined = defined };
+}
+
+/// Failure handshake: the circuit didn't compile, so there's no session to
+/// drive. Emit `error diags=<N>` then one `diag` line per hard error.
+pub fn serveError(writer: anytype, file_path: []const u8, diags: []const Diagnostic) !void {
+    var n: usize = 0;
+    for (diags) |d| {
+        if (d.level == .err) n += 1;
+    }
+    try writer.print("error diags={d}\n", .{n});
+    for (diags) |d| {
+        if (d.level == .err) try writeDiag(writer, file_path, d);
+    }
+}
+
+/// Build the circuit from `topology`, emit the `ready` handshake, then run the
+/// request/response loop until EOF or `quit`. `diags` carries warnings to
+/// report in the handshake (the caller has already gated hard errors).
+///
+/// `set` enqueues-and-settles via `propagateEvent` and `run` calls
+/// `propagate`, mirroring the shipped artifact's `setPin`/`run` exports 1:1,
+/// so a circuit's behavior under `--sim` matches its compiled `.wasm`.
+pub fn serve(
+    parent_alloc: std.mem.Allocator,
+    topology: full_format.FullTopology,
+    file_path: []const u8,
+    diags: []const Diagnostic,
+    reader: anytype,
+    writer: anytype,
+) !void {
+    var sess_arena = std.heap.ArenaAllocator.init(parent_alloc);
+    defer sess_arena.deinit();
+
+    var circuit = engine.Circuit.init() catch return error.InvalidTopology;
+    defer circuit.deinit();
+    var session = try engine_session.Session.build(sess_arena.allocator(), &circuit, topology);
+
+    var warnings: usize = 0;
+    for (diags) |d| {
+        if (d.level == .warning) warnings += 1;
+    }
+    try writer.print("ready proto={d} pins={d} warnings={d}\n", .{
+        PROTO_VERSION, session.inputs.len + session.outputs.len, warnings,
+    });
+    try writePinList(writer, &session);
+    for (diags) |d| {
+        if (d.level == .warning) try writeDiag(writer, file_path, d);
+    }
+
+    var scratch = std.heap.ArenaAllocator.init(parent_alloc);
+    defer scratch.deinit();
+
+    var line_buf: [MAX_LINE]u8 = undefined;
+    while (true) {
+        const maybe_line = reader.readUntilDelimiterOrEof(&line_buf, '\n') catch |err| switch (err) {
+            error.StreamTooLong => {
+                try writeErr(writer, .proto, "command line exceeds limit");
+                break;
+            },
+            else => return err,
+        };
+        const raw = maybe_line orelse break;
+
+        _ = scratch.reset(.retain_capacity);
+        const cmd = protocol.parseLine(scratch.allocator(), raw) catch |err| switch (err) {
+            error.Empty => continue,
+            error.Malformed => {
+                try writeErr(writer, .proto, "malformed command");
+                continue;
+            },
+            error.BadValue => {
+                try writeErr(writer, .badval, "invalid integer literal");
+                continue;
+            },
+            error.OutOfMemory => return err,
+        };
+
+        switch (cmd) {
+            .quit => {
+                try writer.writeAll("ok bye\n");
+                break;
+            },
+            .pins => {
+                try writer.print("pins {d}\n", .{session.inputs.len + session.outputs.len});
+                try writePinList(writer, &session);
+            },
+            .run => {
+                session.circuit.propagate() catch {};
+                try writer.writeAll("ok\n");
+            },
+            .reset => {
+                circuit.deinit();
+                circuit = engine.Circuit.init() catch return error.InvalidTopology;
+                _ = sess_arena.reset(.retain_capacity);
+                session = try engine_session.Session.build(sess_arena.allocator(), &circuit, topology);
+                try writer.writeAll("ok\n");
+            },
+            .set => |a| try doSet(writer, &session, a),
+            .get => |name| try doGet(writer, &session, name),
+            .dump => |which| try doDump(writer, &session, which),
+            .eval => |e| try doEval(writer, &session, e),
+        }
+    }
+}
+
+/// Resolve a `set`/`eval` target to a driveable input and validate its value.
+/// Returns the state to drive, or writes the appropriate `err` and returns null.
+fn resolveDrive(
+    writer: anytype,
+    session: *const engine_session.Session,
+    a: protocol.Assign,
+) !?struct { node: *engine.Component, state: engine.BitVecState } {
+    const pin = session.findInput(a.pin) orelse {
+        const code: protocol.ErrorCode = if (session.findOutput(a.pin) != null) .notin else .nopin;
+        try writeErr(writer, code, a.pin);
+        return null;
+    };
+    const full = widthMask(pin.width);
+    const mask = a.mask orelse full;
+    if ((a.value & ~full) != 0 or (mask & ~full) != 0) {
+        try writeErr(writer, .width, a.pin);
+        return null;
+    }
+    return .{
+        .node = session.nodeById(pin.component_id).?,
+        .state = .{ .value = a.value, .defined = mask, .width = pin.width },
+    };
+}
+
+fn doSet(writer: anytype, session: *const engine_session.Session, a: protocol.Assign) !void {
+    const drive = (try resolveDrive(writer, session, a)) orelse return;
+    session.circuit.propagateEvent(drive.node, drive.state) catch {
+        try writeErr(writer, .proto, "drive failed");
+        return;
+    };
+    try writer.writeAll("ok\n");
+}
+
+fn doGet(writer: anytype, session: *const engine_session.Session, name: []const u8) !void {
+    const pin = session.findOutput(name) orelse session.findInput(name) orelse {
+        try writeErr(writer, .nopin, name);
+        return;
+    };
+    const r = readPin(session, pin);
+    try writer.writeAll("ok ");
+    try protocol.writeHex(writer, r.value);
+    try writer.writeByte(' ');
+    try protocol.writeHex(writer, r.defined);
+    try writer.writeByte('\n');
+}
+
+fn doDump(writer: anytype, session: *const engine_session.Session, which: protocol.Which) !void {
+    const want_in = which == .in or which == .all;
+    const want_out = which == .out or which == .all;
+    var n: usize = 0;
+    if (want_in) n += session.inputs.len;
+    if (want_out) n += session.outputs.len;
+    try writer.print("vals {d}\n", .{n});
+    if (want_in) for (session.inputs) |pin| try writeVal(writer, session, pin);
+    if (want_out) for (session.outputs) |pin| try writeVal(writer, session, pin);
+}
+
+fn writeVal(writer: anytype, session: *const engine_session.Session, pin: engine_session.PinRef) !void {
+    const r = readPin(session, pin);
+    try writer.print("{s} ", .{pin.name});
+    try protocol.writeHex(writer, r.value);
+    try writer.writeByte(' ');
+    try protocol.writeHex(writer, r.defined);
+    try writer.writeByte('\n');
+}
+
+fn doEval(writer: anytype, session: *const engine_session.Session, e: anytype) !void {
+    // Validate everything before mutating state, so a malformed eval is inert.
+    for (e.assigns) |a| {
+        if ((try resolveDrive(writer, session, a)) == null) return;
+    }
+    for (e.queries) |qname| {
+        if (session.findOutput(qname) == null and session.findInput(qname) == null) {
+            try writeErr(writer, .nopin, qname);
+            return;
+        }
+    }
+    for (e.assigns) |a| {
+        const drive = (try resolveDrive(writer, session, a)).?;
+        session.circuit.propagateEvent(drive.node, drive.state) catch {
+            try writeErr(writer, .proto, "drive failed");
+            return;
+        };
+    }
+    try writer.writeAll("ok");
+    for (e.queries) |qname| {
+        const pin = session.findOutput(qname) orelse session.findInput(qname).?;
+        const r = readPin(session, pin);
+        try writer.print(" {s}=", .{qname});
+        try protocol.writeHex(writer, r.value);
+        try writer.writeByte('/');
+        try protocol.writeHex(writer, r.defined);
+    }
+    try writer.writeByte('\n');
+}
+
+// ---------- Tests ----------
+
+const t = std.testing;
+const FullComponentRecord = full_format.FullComponentRecord;
+const FullConnectionRecord = full_format.FullConnectionRecord;
+
+const and_components = [_]FullComponentRecord{
+    .{ .id = 0, .kind = .input_pin, .width = 1, .name = "a", .origin = &.{} },
+    .{ .id = 1, .kind = .input_pin, .width = 1, .name = "b", .origin = &.{} },
+    .{ .id = 2, .kind = .and_gate, .width = 1, .name = "g", .origin = &.{} },
+    .{ .id = 3, .kind = .output_pin, .width = 1, .name = "out", .origin = &.{} },
+};
+const and_connections = [_]FullConnectionRecord{
+    .{ .from_id = 0, .to_id = 2, .port = @intFromEnum(full_format.PortName.a) },
+    .{ .from_id = 1, .to_id = 2, .port = @intFromEnum(full_format.PortName.b) },
+    .{ .from_id = 2, .to_id = 3, .port = @intFromEnum(full_format.PortName.in) },
+};
+
+fn runScript(buf: *std.ArrayList(u8), script: []const u8) !void {
+    const topology: full_format.FullTopology = .{ .components = &and_components, .connections = &and_connections };
+    var fbs = std.io.fixedBufferStream(script);
+    try serve(t.allocator, topology, "and.circ", &.{}, fbs.reader(), buf.writer(t.allocator));
+}
+
+test "serve: handshake, set/run/get on the AND gate" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(t.allocator);
+    try runScript(&buf, "set a 1\nset b 1\nrun\nget out\nquit\n");
+    const out = buf.items;
+    try t.expect(std.mem.startsWith(u8, out, "ready proto=1 pins=3 warnings=0\n"));
+    try t.expect(std.mem.indexOf(u8, out, "pin a in 1\n") != null);
+    try t.expect(std.mem.indexOf(u8, out, "pin out out 1\n") != null);
+    try t.expect(std.mem.indexOf(u8, out, "ok 0x1 0x1\n") != null);
+    try t.expect(std.mem.endsWith(u8, out, "ok bye\n"));
+}
+
+test "serve: AND of 1 and 0 settles low" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(t.allocator);
+    try runScript(&buf, "set a 1\nset b 0\nget out\n");
+    try t.expect(std.mem.indexOf(u8, buf.items, "ok 0x0 0x1\n") != null);
+}
+
+test "serve: eval one-shot vector" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(t.allocator);
+    try runScript(&buf, "eval a=1 b=1 => out\n");
+    try t.expect(std.mem.indexOf(u8, buf.items, "ok out=0x1/0x1\n") != null);
+}
+
+test "serve: undefined input propagates to undefined output" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(t.allocator);
+    // a undefined, b high: 1 AND x = x, so out is undefined (defined mask 0).
+    try runScript(&buf, "set a 0 0\nset b 1\nget out\n");
+    try t.expect(std.mem.indexOf(u8, buf.items, "ok 0x0 0x0\n") != null);
+}
+
+test "serve: error replies" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(t.allocator);
+    try runScript(&buf, "set a 2\nget nope\nset out 1\nbogus\nset a zz\n");
+    const out = buf.items;
+    try t.expect(std.mem.indexOf(u8, out, "err E_WIDTH a\n") != null);
+    try t.expect(std.mem.indexOf(u8, out, "err E_NOPIN nope\n") != null);
+    try t.expect(std.mem.indexOf(u8, out, "err E_NOTIN out\n") != null);
+    try t.expect(std.mem.indexOf(u8, out, "err E_PROTO ") != null);
+    try t.expect(std.mem.indexOf(u8, out, "err E_BADVAL ") != null);
+}
+
+test "serve: reset clears state to undefined" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(t.allocator);
+    try runScript(&buf, "set a 1\nset b 1\nget out\nreset\nget out\n");
+    // First get is high; after reset the AND output is undefined again.
+    try t.expect(std.mem.indexOf(u8, buf.items, "ok 0x1 0x1\n") != null);
+    try t.expect(std.mem.indexOf(u8, buf.items, "ok 0x0 0x0\n") != null);
+}

--- a/lib/sim/protocol.zig
+++ b/lib/sim/protocol.zig
@@ -1,0 +1,228 @@
+const std = @import("std");
+
+/// Stable error codes the `--sim` protocol reports as `err <CODE> <message>`.
+/// Versioned alongside `proto=<N>`; treat as an append-only surface.
+pub const ErrorCode = enum {
+    proto, // unknown or malformed command
+    nopin, // no such pin
+    notin, // `set` target is not a top-level input
+    width, // value or mask has bits beyond the pin's width
+    badval, // not a valid integer literal
+    nosettle, // `run` hit the iteration cap without settling
+
+    pub fn tag(self: ErrorCode) []const u8 {
+        return switch (self) {
+            .proto => "E_PROTO",
+            .nopin => "E_NOPIN",
+            .notin => "E_NOTIN",
+            .width => "E_WIDTH",
+            .badval => "E_BADVAL",
+            .nosettle => "E_NOSETTLE",
+        };
+    }
+};
+
+pub const Which = enum { in, out, all };
+
+/// A `pin=value[/mask]` assignment. `mask == null` means "fully defined",
+/// resolved against the pin's width by the drive loop.
+pub const Assign = struct {
+    pin: []const u8,
+    value: u64,
+    mask: ?u64,
+};
+
+pub const Command = union(enum) {
+    pins,
+    set: Assign,
+    get: []const u8,
+    dump: Which,
+    run,
+    eval: struct {
+        assigns: []const Assign,
+        queries: []const []const u8,
+    },
+    reset,
+    quit,
+};
+
+pub const ParseError = error{
+    /// Blank or comment line: the loop skips it and sends no reply.
+    Empty,
+    /// Unknown verb or wrong argument shape -> `err E_PROTO`.
+    Malformed,
+    /// A value/mask token is not a valid integer -> `err E_BADVAL`.
+    BadValue,
+    OutOfMemory,
+};
+
+/// Parse an unsigned integer literal. Base is inferred from the prefix:
+/// `0x` hex, `0o` octal, `0b` binary, otherwise decimal (`_` separators ok).
+pub fn parseValue(text: []const u8) error{BadValue}!u64 {
+    return std.fmt.parseInt(u64, text, 0) catch error.BadValue;
+}
+
+/// Emit a value in the protocol's canonical form: lowercase hex, `0x`-prefixed.
+pub fn writeHex(writer: anytype, value: u64) !void {
+    try writer.print("0x{x}", .{value});
+}
+
+fn parseWhich(s: []const u8) ?Which {
+    if (std.mem.eql(u8, s, "in")) return .in;
+    if (std.mem.eql(u8, s, "out")) return .out;
+    if (std.mem.eql(u8, s, "all")) return .all;
+    return null;
+}
+
+/// Parse one request line. `alloc` is only used for `eval`'s variable-length
+/// operand lists; every returned slice (and the pin-name slices inside it)
+/// borrows from `raw`, so callers must finish using the command before the
+/// next line overwrites the buffer.
+pub fn parseLine(alloc: std.mem.Allocator, raw: []const u8) ParseError!Command {
+    const line = std.mem.trim(u8, raw, " \t\r\n");
+    if (line.len == 0 or line[0] == '#') return error.Empty;
+
+    var it = std.mem.tokenizeAny(u8, line, " \t");
+    const verb = it.next() orelse return error.Empty;
+
+    if (std.mem.eql(u8, verb, "pins")) return .pins;
+    if (std.mem.eql(u8, verb, "run")) return .run;
+    if (std.mem.eql(u8, verb, "reset")) return .reset;
+    if (std.mem.eql(u8, verb, "quit")) return .quit;
+
+    if (std.mem.eql(u8, verb, "get")) {
+        const pin = it.next() orelse return error.Malformed;
+        if (it.next() != null) return error.Malformed;
+        return .{ .get = pin };
+    }
+
+    if (std.mem.eql(u8, verb, "dump")) {
+        const which_str = it.next() orelse return error.Malformed;
+        if (it.next() != null) return error.Malformed;
+        return .{ .dump = parseWhich(which_str) orelse return error.Malformed };
+    }
+
+    if (std.mem.eql(u8, verb, "set")) {
+        const pin = it.next() orelse return error.Malformed;
+        const value_str = it.next() orelse return error.Malformed;
+        const value = try parseValue(value_str);
+        var mask: ?u64 = null;
+        if (it.next()) |mask_str| {
+            mask = try parseValue(mask_str);
+            if (it.next() != null) return error.Malformed;
+        }
+        return .{ .set = .{ .pin = pin, .value = value, .mask = mask } };
+    }
+
+    if (std.mem.eql(u8, verb, "eval")) {
+        var assigns: std.ArrayList(Assign) = .{};
+        errdefer assigns.deinit(alloc);
+        var queries: std.ArrayList([]const u8) = .{};
+        errdefer queries.deinit(alloc);
+        var saw_arrow = false;
+        while (it.next()) |tok| {
+            if (std.mem.eql(u8, tok, "=>")) {
+                if (saw_arrow) return error.Malformed;
+                saw_arrow = true;
+                continue;
+            }
+            if (saw_arrow) {
+                try queries.append(alloc, tok);
+                continue;
+            }
+            const eq = std.mem.indexOfScalar(u8, tok, '=') orelse return error.Malformed;
+            if (eq == 0) return error.Malformed;
+            const pin = tok[0..eq];
+            const rhs = tok[eq + 1 ..];
+            if (rhs.len == 0) return error.Malformed;
+            if (std.mem.indexOfScalar(u8, rhs, '/')) |slash| {
+                try assigns.append(alloc, .{
+                    .pin = pin,
+                    .value = try parseValue(rhs[0..slash]),
+                    .mask = try parseValue(rhs[slash + 1 ..]),
+                });
+            } else {
+                try assigns.append(alloc, .{ .pin = pin, .value = try parseValue(rhs), .mask = null });
+            }
+        }
+        if (!saw_arrow) return error.Malformed;
+        return .{ .eval = .{
+            .assigns = try assigns.toOwnedSlice(alloc),
+            .queries = try queries.toOwnedSlice(alloc),
+        } };
+    }
+
+    return error.Malformed;
+}
+
+// ---------- Tests ----------
+
+const t = std.testing;
+
+test "parseValue across radixes" {
+    try t.expectEqual(@as(u64, 3), try parseValue("3"));
+    try t.expectEqual(@as(u64, 31), try parseValue("0x1f"));
+    try t.expectEqual(@as(u64, 5), try parseValue("0b101"));
+    try t.expectEqual(@as(u64, 15), try parseValue("0o17"));
+    try t.expectError(error.BadValue, parseValue("abc"));
+    try t.expectError(error.BadValue, parseValue(""));
+    try t.expectError(error.BadValue, parseValue("-1"));
+}
+
+test "parseLine simple commands" {
+    try t.expect(try parseLine(t.allocator, "pins") == .pins);
+    try t.expect(try parseLine(t.allocator, "run") == .run);
+    try t.expect(try parseLine(t.allocator, "reset") == .reset);
+    try t.expect(try parseLine(t.allocator, "quit") == .quit);
+    try t.expectError(error.Empty, parseLine(t.allocator, ""));
+    try t.expectError(error.Empty, parseLine(t.allocator, "  # a comment"));
+    try t.expectError(error.Malformed, parseLine(t.allocator, "bogus"));
+}
+
+test "parseLine set with and without mask" {
+    const a = try parseLine(t.allocator, "set a 1");
+    try t.expectEqualStrings("a", a.set.pin);
+    try t.expectEqual(@as(u64, 1), a.set.value);
+    try t.expect(a.set.mask == null);
+
+    const b = try parseLine(t.allocator, "set bus 0x5 0xf");
+    try t.expectEqualStrings("bus", b.set.pin);
+    try t.expectEqual(@as(u64, 5), b.set.value);
+    try t.expectEqual(@as(u64, 15), b.set.mask.?);
+
+    try t.expectError(error.Malformed, parseLine(t.allocator, "set a"));
+    try t.expectError(error.BadValue, parseLine(t.allocator, "set a zz"));
+    try t.expectError(error.Malformed, parseLine(t.allocator, "set a 1 2 3"));
+}
+
+test "parseLine get and dump" {
+    try t.expectEqualStrings("out", (try parseLine(t.allocator, "get out")).get);
+    try t.expectError(error.Malformed, parseLine(t.allocator, "get"));
+    try t.expectEqual(Which.all, (try parseLine(t.allocator, "dump all")).dump);
+    try t.expectError(error.Malformed, parseLine(t.allocator, "dump sideways"));
+}
+
+test "parseLine eval" {
+    const cmd = try parseLine(t.allocator, "eval a=3 b=0xf/0xf => out cout");
+    defer t.allocator.free(cmd.eval.assigns);
+    defer t.allocator.free(cmd.eval.queries);
+    try t.expectEqual(@as(usize, 2), cmd.eval.assigns.len);
+    try t.expectEqualStrings("a", cmd.eval.assigns[0].pin);
+    try t.expectEqual(@as(u64, 3), cmd.eval.assigns[0].value);
+    try t.expect(cmd.eval.assigns[0].mask == null);
+    try t.expectEqual(@as(u64, 15), cmd.eval.assigns[1].mask.?);
+    try t.expectEqual(@as(usize, 2), cmd.eval.queries.len);
+    try t.expectEqualStrings("cout", cmd.eval.queries[1]);
+
+    try t.expectError(error.Malformed, parseLine(t.allocator, "eval a=1"));
+}
+
+test "writeHex canonical form" {
+    var buf: [32]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeHex(fbs.writer(), 0);
+    try t.expectEqualStrings("0x0", fbs.getWritten());
+    fbs.reset();
+    try writeHex(fbs.writer(), 31);
+    try t.expectEqualStrings("0x1f", fbs.getWritten());
+}

--- a/lib/truth_table/builder.zig
+++ b/lib/truth_table/builder.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const engine = @import("circuit");
 const full_format = @import("full_format");
+const engine_session = @import("engine_session");
 
 /// Re-export of the engine's `BitVecState`. Callers that only depend on
 /// the truth-table layer can construct cell values without taking a
@@ -29,11 +30,9 @@ pub const State = enum(u2) {
     }
 };
 
-pub const PinRef = struct {
-    name: []const u8,
-    component_id: u32,
-    width: u8,
-};
+/// Re-exported from the shared engine session; existing consumers
+/// (`Header`, the renderers) keep referring to `builder.PinRef`.
+pub const PinRef = engine_session.PinRef;
 
 pub const Header = struct {
     inputs: []const PinRef,
@@ -88,16 +87,6 @@ pub const BuildError = error{
     InvalidTopology,
 };
 
-fn portByteToName(port: u8) ![]const u8 {
-    const port_name = std.meta.intToEnum(full_format.PortName, port) catch return error.InvalidTopology;
-    return switch (port_name) {
-        .in => "in",
-        .a => "a",
-        .b => "b",
-        .out => "out",
-    };
-}
-
 fn widthMaskU64(width: u8) u64 {
     if (width == 0) return 0;
     if (width >= 64) return std.math.maxInt(u64);
@@ -131,16 +120,12 @@ pub fn build(
     // sub-circuits also emit input_pin / output_pin primitives, but those are
     // wired through to root drivers and aren't independent test vectors. The
     // origin chain is empty exactly for root-level components.
-    var input_count: usize = 0;
     var output_count: usize = 0;
     var total_input_bits: u32 = 0;
     for (topology.components) |comp| {
         if (comp.origin.len != 0) continue;
         switch (comp.kind) {
-            .input_pin => {
-                input_count += 1;
-                total_input_bits += comp.width;
-            },
+            .input_pin => total_input_bits += comp.width,
             .output_pin => output_count += 1,
             else => {},
         }
@@ -148,69 +133,11 @@ pub fn build(
     if (total_input_bits > options.max_input_bits) return error.TooManyInputs;
     if (output_count == 0) return error.NoOutputs;
 
-    var inputs = try arena_alloc.alloc(PinRef, input_count);
-    var outputs = try arena_alloc.alloc(PinRef, output_count);
-    var i_idx: usize = 0;
-    var o_idx: usize = 0;
-    for (topology.components) |comp| {
-        if (comp.origin.len != 0) continue;
-        switch (comp.kind) {
-            .input_pin => {
-                inputs[i_idx] = .{ .name = comp.name, .component_id = comp.id, .width = comp.width };
-                i_idx += 1;
-            },
-            .output_pin => {
-                outputs[o_idx] = .{ .name = comp.name, .component_id = comp.id, .width = comp.width };
-                o_idx += 1;
-            },
-            else => {},
-        }
-    }
-
     var circuit = engine.Circuit.init() catch return error.InvalidTopology;
     defer circuit.deinit();
-
-    var id_to_node = std.AutoHashMap(u32, *engine.Component).init(arena_alloc);
-    try id_to_node.ensureTotalCapacity(@intCast(topology.components.len));
-    for (topology.components) |comp| {
-        const node = switch (comp.kind) {
-            .input_pin => circuit.createComponent(.{ .input_pin_gate = .{} }, comp.width),
-            .not_gate => circuit.createComponent(.{ .not_gate = .{} }, comp.width),
-            .and_gate => circuit.createComponent(.{ .and_gate = .{} }, comp.width),
-            .wire => circuit.createComponent(.{ .wire = .{} }, comp.width),
-            .led => circuit.createComponent(.{ .led = .{} }, comp.width),
-            .output_pin => circuit.createComponent(.{ .output_pin = .{} }, comp.width),
-            .slice => blk: {
-                const aux = switch (comp.aux) {
-                    .slice => |s| s,
-                    else => return error.InvalidTopology,
-                };
-                break :blk circuit.createComponent(
-                    .{ .slice = .{ .lo = aux.lo, .hi = aux.hi } },
-                    comp.width,
-                );
-            },
-            .concat => circuit.createComponent(.{ .concat = .{} }, comp.width),
-        } catch return error.InvalidTopology;
-        node.id = comp.id;
-        id_to_node.putAssumeCapacity(comp.id, node);
-    }
-
-    for (topology.connections) |conn| {
-        const from_node = id_to_node.get(conn.from_id) orelse return error.InvalidTopology;
-        const to_node = id_to_node.get(conn.to_id) orelse return error.InvalidTopology;
-        // Concat destinations interpret the port byte as an operand
-        // index, not a `PortName`. Format the byte back into the
-        // `operand_<N>` string the engine's `connect()` expects.
-        if (to_node.kind == .concat) {
-            var port_buf: [16]u8 = undefined;
-            const port_str = std.fmt.bufPrint(&port_buf, "operand_{d}", .{conn.port}) catch return error.InvalidTopology;
-            circuit.connect(.{ from_node, "out" }, .{ to_node, port_str }) catch return error.InvalidTopology;
-        } else {
-            const port_str = portByteToName(conn.port) catch return error.InvalidTopology;
-            circuit.connect(.{ from_node, "out" }, .{ to_node, port_str }) catch return error.InvalidTopology;
-        }
-    }
+    const session = try engine_session.Session.build(arena_alloc, &circuit, topology);
+    const inputs = session.inputs;
+    const outputs = session.outputs;
 
     const row_count: u64 = if (total_input_bits == 0) 1 else (@as(u64, 1) << @intCast(total_input_bits));
     var rows = try arena_alloc.alloc(Row, @intCast(row_count));
@@ -228,14 +155,14 @@ pub fn build(
                 .defined = pin_mask,
                 .width = pin.width,
             };
-            const node = id_to_node.get(pin.component_id) orelse return error.InvalidTopology;
+            const node = session.nodeById(pin.component_id) orelse return error.InvalidTopology;
             circuit.propagateEvent(node, new_state) catch return error.InvalidTopology;
             bit_offset += pin.width;
         }
 
         const row_outputs = try arena_alloc.alloc(engine.BitVecState, output_count);
         for (outputs, 0..) |pin, idx| {
-            const node = id_to_node.get(pin.component_id) orelse return error.InvalidTopology;
+            const node = session.nodeById(pin.component_id) orelse return error.InvalidTopology;
             row_outputs[idx] = circuit.readState(node.state_handle);
         }
         rows[@intCast(mask)] = .{ .input_bits = mask, .outputs = row_outputs };


### PR DESCRIPTION
## Summary
- Add `circ-compile <in>.circ --sim`: a line-oriented stdio request/response protocol (proto=1) that compiles a circuit then drives it by pin name (`set`/`get`/`run`/`eval`/`dump`/`reset`), so an external process can set inputs, settle, and read outputs without a WASM host.
- Extract the `FullTopology` to live `Circuit` construction plus pin-name resolution out of the truth-table builder into a shared `lib/engine_session.zig`, so `--sim` and `--truth-table` build the same circuit the same way.
- `set`/`run`/`get` map 1:1 onto the artifact's `setPin`/`run`/`getOutput*` exports (each `set` settles, mirroring the shipped `.wasm`), so a circuit behaves identically under `--sim` and when compiled. Values carry a `(value, mask)` pair, making undefined bits first-class; reads emit canonical hex. Protocol spec: `DOCS/sim-protocol.md`.

This is the engine for a planned detached, host-language test runner (modeled on circ-lsp) that spawns `circ-compile --sim`; that runner lives in its own repo and is out of scope here.

## Test plan
- [x] `zig build test` after clearing `.zig-cache`: protocol codec units, `--sim` loop integration (handshake, every command, error replies, reset), engine_session, and args parsing/exclusivity.
- [x] Truth-table goldens unchanged (the engine_session extraction is behavior-preserving).
- [x] End-to-end: `printf 'set a 1\nset b 1\nrun\nget out\nquit\n' | circ-compile and_gate.circ --sim` returns `ok 0x1 0x1`.