### PR TITLE
test: move slow emit-zig behavioral smoke out of default zig build test

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,4 +46,8 @@ jobs:
         # divergence is investigated.
         env:
           SKIP_WASM_E2E: "1"
-        run: zig build test --summary all
+        # `test-all` = the fast `test` step plus `test-emit` (the experimental
+        # --emit-zig backend smoke, which spawns nested wasm builds per fixture).
+        # The dev-loop default `zig build test` omits `test-emit` for speed; CI
+        # runs both so emit-backend regressions still gate merges.
+        run: zig build test-all --summary all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | --- | --- |
 | `zig build` | Default. Builds the runtime template into `zig-out/lib/circ-runtime.wasm` and installs the CLI. |
 | `zig build circ-compile` | Builds the CLI to `zig-out/bin/circ-compile`. |
-| `zig build test` | Full test suite, aggregated from many per-module `addTest` artifacts in `build.zig`. |
+| `zig build test` | Fast suite (dev-loop default), aggregated from many per-module `addTest` artifacts in `build.zig`. Excludes the slow emit-zig behavioral smoke; circuit behavior on the production path is still fully covered via `tests/e2e/serializer_fixtures_test.zig`. |
+| `zig build test-emit` | Emit-zig backend behavioral smoke (`tests/emit/{behavior,project_behavior}_test.zig`). Slow: every fixture spawns a nested `zig build wasm`. Guards the experimental `--emit-zig` pipeline only. |
+| `zig build test-all` | `test` + `test-emit`. The full gate CI runs (see `.github/workflows/pr-tests.yml`). |
 | `zig build bench` | Engine benchmark over the truth-table fixture corpus, compared against `tests/fixtures/bench/engine.bench.golden`. Counters are asserted; wall-clock is not. |
 | `zig build parser:archive` | Rebuilds `lib/parser/parser.a` from `lib/parser/shim/shim.go` via `go build -buildmode=c-archive`. Runs automatically as a dependency of `circ-compile`. |
 | `zig build parser:gen` | Regenerates `lib/parser/parser.go` from `lib/grammar/proto-circ.peg`. Only when the grammar changes; requires langlang on `PATH`. |
@@ -31,7 +33,7 @@ Useful environment variables:
 - `UPDATE_GOLDENS=1` regenerates fixtures under `tests/fixtures/expected-*/` instead of comparing against them. Diff the result before committing.
 - `NO_COLOR=1` strips ANSI from `--preview` output.
 
-There is no `-Dtest-filter` flag wired into `build.zig`. To run a single test module in isolation, invoke `zig test <path>` against its root file (e.g. `zig test tests/validator/run_test.zig`); the `test` step in `build.zig` is the canonical aggregator.
+There is no `-Dtest-filter` flag wired into `build.zig`. To run a single test module in isolation, invoke `zig test <path>` against its root file (e.g. `zig test tests/validator/run_test.zig`). The `test` step is the fast dev-loop aggregator; `zig build test-all` adds the slow emit-zig smoke (`test-emit`) and is the full gate CI runs.
 
 ## CLI shape
 

--- a/DOCS/architecture.md
+++ b/DOCS/architecture.md
@@ -153,6 +153,7 @@ This is the heart of the compiler:
 |------------------------|-------------------------------------|----------------------------------------------------------------------|
 | `circ-compile`         | `zig-out/bin/circ-compile`          | The `.circ` → `.wasm` CLI compiler.                                  |
 | (default `zig build`)  | `zig-out/lib/circ-runtime.wasm`     | The prebuilt runtime template embedded into compiled artifacts.       |
-| `zig build test`       | runs unit + integration tests       | Suite under `tests/`. Set `CIRC_SKIP_PERF=1` to skip the perf smoke.  |
+| `zig build test`       | fast unit + integration suite       | Suite under `tests/` (dev-loop default). Set `CIRC_SKIP_PERF=1` to skip the perf smoke.  |
+| `zig build test-all`   | `test` + slow emit-zig smoke        | Adds `test-emit` (a nested `zig build wasm` per fixture); the gate CI runs.  |
 
 There is no longer a "TypeScript SDK" target, a Canvas-2D rendering layer, or a `compiler:run` step — those were prototypes that have been removed in favour of the CLI-only model.

--- a/DOCS/index.md
+++ b/DOCS/index.md
@@ -111,5 +111,6 @@ zig build circ-compile               # → zig-out/bin/circ-compile
 zig build                             # → zig-out/lib/circ-runtime.wasm
 
 # Tests
-zig build test                        # set CIRC_SKIP_PERF=1 to skip perf smoke
+zig build test                        # fast dev-loop suite; CIRC_SKIP_PERF=1 skips perf smoke
+zig build test-all                    # test + test-emit (slow emit-zig smoke); what CI runs
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The binary lands at `zig-out/bin/circ-compile`. Run the test suite with:
 zig build test
 ```
 
-(Set `CIRC_SKIP_PERF=1` to skip the smoke perf test in noisy CI environments.)
+This is the fast dev-loop suite. `zig build test-all` additionally runs the slow emit-zig backend smoke (`test-emit`, a nested `zig build wasm` per fixture) and is what CI runs. (Set `CIRC_SKIP_PERF=1` to skip the smoke perf test in noisy CI environments.)
 
 ## Usage
 

--- a/build.zig
+++ b/build.zig
@@ -979,7 +979,6 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_emit_build_fn_tests.step);
     test_step.dependOn(&run_emit_metadata_tests.step);
     test_step.dependOn(&run_emit_full_tests.step);
-    test_step.dependOn(&run_emit_behavior_tests.step);
     test_step.dependOn(&run_cli_args_tests.step);
     test_step.dependOn(&run_preview_render_color_tests.step);
     test_step.dependOn(&run_preview_render_canvas_tests.step);
@@ -1042,7 +1041,7 @@ pub fn build(b: *std.Build) void {
     linkParserArchive(b, project_behavior_tests, build_archive_cmd);
     project_behavior_tests.linkLibC();
     const run_project_behavior_tests = b.addRunArtifact(project_behavior_tests);
-    test_step.dependOn(&run_project_behavior_tests.step);
+    // Detached from `test`; wired into `test-emit` near the end of build().
 
     const topology_format_tests_mod = b.createModule(.{
         .root_source_file = b.path("lib/topology/format.zig"),
@@ -1510,6 +1509,21 @@ pub fn build(b: *std.Build) void {
     });
     const run_topology_interpreter_tests = b.addRunArtifact(topology_interpreter_tests);
     test_step.dependOn(&run_topology_interpreter_tests.step);
+
+    // The emit-zig backend behavioral smoke tests each spawn a nested
+    // `zig build wasm` per fixture, which is dramatically slower than the rest
+    // of the suite. They guard the experimental --emit-zig pipeline only;
+    // circuit *behavior* on the production path (prebuilt runtime + topology
+    // sections) is already covered by serializer_fixtures_test, which stays in
+    // the default `test` step. So keep them out of the dev-loop `test` step and
+    // behind an opt-in `test-emit` step. CI runs everything via `test-all`.
+    const test_emit_step = b.step("test-emit", "Emit-zig backend behavioral smoke (nested wasm builds; slow)");
+    test_emit_step.dependOn(&run_emit_behavior_tests.step);
+    test_emit_step.dependOn(&run_project_behavior_tests.step);
+
+    const test_all_step = b.step("test-all", "Full suite: `test` plus the emit-zig smoke (`test-emit`)");
+    test_all_step.dependOn(test_step);
+    test_all_step.dependOn(test_emit_step);
 
     // ---- Engine benchmark step ----
     // The bench step compiles a *parallel* circuit module with

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,8 @@
 # Tests and Fixtures
 
-This project uses `zig build test` as the canonical local test command.
+This project uses `zig build test` as the canonical local test command — the fast,
+dev-loop suite. `zig build test-all` additionally runs `test-emit`, the slow emit-zig
+backend smoke that spawns a nested `zig build wasm` per fixture, and is what CI runs.
 Behavioral WASM harness tests also require `node` on your `PATH`.
 
 Fixture directories are organized by artifact kind:

--- a/tests/cli/integration_test.zig
+++ b/tests/cli/integration_test.zig
@@ -35,10 +35,18 @@ fn exitCode(term: std.process.Child.Term) i32 {
     };
 }
 
+// `zig build circ-compile` produces an identical binary for every test in this
+// file, so build it at most once. Zig runs a test binary's tests serially on a
+// single thread, so a plain flag suffices (no atomics / std.once). A failed
+// first build leaves the flag false, so later tests retry rather than skip.
+var cli_built = false;
+
 fn buildCli() !void {
+    if (cli_built) return;
     var result = try run(&.{ "zig", "build", "circ-compile" });
     defer result.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(i32, 0), exitCode(result.term));
+    cli_built = true;
 }
 
 fn expectFileExists(path: []const u8) !void {

--- a/tests/emit/behavior_test.zig
+++ b/tests/emit/behavior_test.zig
@@ -1,3 +1,13 @@
+//! Emit-zig backend smoke (single-module path).
+//!
+//! Circuit *behavior* for the whole fixture corpus is covered cheaply by the
+//! production path in tests/e2e/serializer_fixtures_test.zig (prebuilt runtime
+//! + topology sections, no per-fixture compile). This file's only remaining job
+//! is to guard that the experimental `--emit-zig` standalone-source backend
+//! still emits runnable wasm, so it keeps a minimal set of fixtures and is wired
+//! into the opt-in `test-emit` build step rather than the default `test` step.
+//! Each kept fixture triggers one nested `zig build wasm` via wasm_run, so add
+//! new cases sparingly.
 const std = @import("std");
 const translate = @import("translate");
 const resolver = @import("resolver");
@@ -156,7 +166,11 @@ fn runBehaviorFixture(fixture: BehaviorFixture) !void {
     try std.testing.expectEqualStrings(script_and_expected.expected_stdout, stdout);
 }
 
-test "behavior fixture: inverter" {
+// Minimal emit-zig single-module smoke set. The full behavioral corpus runs on
+// the production path in serializer_fixtures_test.zig; these two only prove the
+// --emit-zig backend still emits runnable wasm. `inverter` is the smallest
+// circuit (one NOT gate); `chain` exercises multi-stage wire propagation.
+test "emit-zig smoke: inverter" {
     try runBehaviorFixture(.{
         .source_path = "tests/fixtures/circuits/inverter.circ",
         .source_name = "inverter.circ",
@@ -164,101 +178,10 @@ test "behavior fixture: inverter" {
     });
 }
 
-test "behavior fixture: and gate" {
-    try runBehaviorFixture(.{
-        .source_path = "tests/fixtures/circuits/and_gate.circ",
-        .source_name = "and_gate.circ",
-        .expected_path = "tests/fixtures/expected-wasm/and_gate.txt",
-    });
-}
-
-test "behavior fixture: and of not" {
-    try runBehaviorFixture(.{
-        .source_path = "tests/fixtures/circuits/and_of_not.circ",
-        .source_name = "and_of_not.circ",
-        .expected_path = "tests/fixtures/expected-wasm/and_of_not.txt",
-    });
-}
-
-test "behavior fixture: chain" {
+test "emit-zig smoke: chain" {
     try runBehaviorFixture(.{
         .source_path = "tests/fixtures/circuits/chain.circ",
         .source_name = "chain.circ",
         .expected_path = "tests/fixtures/expected-wasm/chain.txt",
     });
-}
-
-test "behavior fixture: unused input" {
-    try runBehaviorFixture(.{
-        .source_path = "tests/fixtures/circuits/unused_input.circ",
-        .source_name = "unused_input.circ",
-        .expected_path = "tests/fixtures/expected-wasm/unused_input.txt",
-    });
-}
-
-const edge_behavior_fixtures = [_]BehaviorFixture{
-    .{
-        .source_path = "tests/fixtures/circuits/edge_empty_circuit.circ",
-        .source_name = "edge_empty_circuit.circ",
-        .expected_path = "tests/fixtures/expected-wasm/edge_empty_circuit.txt",
-    },
-    .{
-        .source_path = "tests/fixtures/circuits/edge_single_component.circ",
-        .source_name = "edge_single_component.circ",
-        .expected_path = "tests/fixtures/expected-wasm/edge_single_component.txt",
-    },
-    .{
-        .source_path = "tests/fixtures/circuits/edge_deep_anonymous.circ",
-        .source_name = "edge_deep_anonymous.circ",
-        .expected_path = "tests/fixtures/expected-wasm/edge_deep_anonymous.txt",
-    },
-    .{
-        .source_path = "tests/fixtures/circuits/edge_wide_fanin.circ",
-        .source_name = "edge_wide_fanin.circ",
-        .expected_path = "tests/fixtures/expected-wasm/edge_wide_fanin.txt",
-    },
-    .{
-        .source_path = "tests/fixtures/circuits/edge_wide_fanout.circ",
-        .source_name = "edge_wide_fanout.circ",
-        .expected_path = "tests/fixtures/expected-wasm/edge_wide_fanout.txt",
-    },
-};
-
-test "Phase 9 edge: single-file wasm fixtures" {
-    for (edge_behavior_fixtures) |fx| {
-        try runBehaviorFixture(fx);
-    }
-}
-
-const stress_behavior_fixtures = [_]BehaviorFixture{
-    .{
-        .source_path = "tests/fixtures/circuits/stress_chain_100.circ",
-        .source_name = "stress_chain_100.circ",
-        .expected_path = "tests/fixtures/expected-wasm/stress_chain_100.txt",
-    },
-    .{
-        .source_path = "tests/fixtures/circuits/stress_grid_10x10.circ",
-        .source_name = "stress_grid_10x10.circ",
-        .expected_path = "tests/fixtures/expected-wasm/stress_grid_10x10.txt",
-    },
-};
-
-const regression_behavior_fixtures = [_]BehaviorFixture{
-    .{
-        .source_path = "tests/fixtures/circuits/regression_led_out_drives_gate.circ",
-        .source_name = "regression_led_out_drives_gate.circ",
-        .expected_path = "tests/fixtures/expected-wasm/regression_led_out_drives_gate.txt",
-    },
-};
-
-test "Phase 9 regression: single-file wasm fixtures" {
-    for (regression_behavior_fixtures) |fx| {
-        try runBehaviorFixture(fx);
-    }
-}
-
-test "Phase 9 stress: large single-file wasm fixtures" {
-    for (stress_behavior_fixtures) |fx| {
-        try runBehaviorFixture(fx);
-    }
 }

--- a/tests/emit/project_behavior_test.zig
+++ b/tests/emit/project_behavior_test.zig
@@ -1,3 +1,13 @@
+//! Emit-zig backend smoke (multi-file project path).
+//!
+//! Circuit *behavior* for the whole fixture corpus is covered cheaply by the
+//! production path in tests/e2e/serializer_fixtures_test.zig (prebuilt runtime
+//! + topology sections, no per-fixture compile). This file's only remaining job
+//! is to guard that the experimental `--emit-zig` project backend
+//! (emit_project.emitProjectSource) still emits runnable wasm, so it keeps a
+//! minimal set of fixtures and is wired into the opt-in `test-emit` build step
+//! rather than the default `test` step. Each kept fixture triggers one nested
+//! `zig build wasm` via wasm_run, so add new cases sparingly.
 const std = @import("std");
 const scan_imports = @import("scan_imports");
 const import_cycle = @import("import_cycle");
@@ -176,100 +186,12 @@ fn runFixture(fixture: Fixture) !void {
     try std.testing.expectEqualStrings(script_and_expected.expected_stdout, stdout);
 }
 
-test "project behavior: passthrough_chain" {
-    try runFixture(.{
-        .name = "passthrough_chain",
-        .root_path = "tests/fixtures/projects/passthrough_chain/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/passthrough_chain.txt",
-    });
-}
-
-test "project behavior: and_pair" {
-    try runFixture(.{
-        .name = "and_pair",
-        .root_path = "tests/fixtures/projects/and_pair/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/and_pair.txt",
-    });
-}
-
-test "project behavior: nested_invert" {
-    try runFixture(.{
-        .name = "nested_invert",
-        .root_path = "tests/fixtures/projects/nested_invert/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/nested_invert.txt",
-    });
-}
-
-test "project behavior: diamond shared base" {
-    try runFixture(.{
-        .name = "diamond",
-        .root_path = "tests/fixtures/projects/diamond/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/diamond.txt",
-    });
-}
-
-test "project behavior: deep_chain" {
-    try runFixture(.{
-        .name = "deep_chain",
-        .root_path = "tests/fixtures/projects/deep_chain/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/deep_chain.txt",
-    });
-}
-
-test "project behavior: same_name_half_adder" {
-    try runFixture(.{
-        .name = "same_name_half_adder",
-        .root_path = "tests/fixtures/projects/same_name_half_adder/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/same_name_half_adder.txt",
-    });
-}
-
-const builtin_truth_fixtures = [_]Fixture{
-    .{
-        .name = "builtin_or",
-        .root_path = "tests/fixtures/circuits/builtin_or.circ",
-        .source_name = "builtin_or.circ",
-        .spec_path = "tests/fixtures/expected-wasm/builtin_or.txt",
-    },
-    .{
-        .name = "builtin_nand",
-        .root_path = "tests/fixtures/circuits/builtin_nand.circ",
-        .source_name = "builtin_nand.circ",
-        .spec_path = "tests/fixtures/expected-wasm/builtin_nand.txt",
-    },
-    .{
-        .name = "builtin_nor",
-        .root_path = "tests/fixtures/circuits/builtin_nor.circ",
-        .source_name = "builtin_nor.circ",
-        .spec_path = "tests/fixtures/expected-wasm/builtin_nor.txt",
-    },
-    .{
-        .name = "builtin_xor",
-        .root_path = "tests/fixtures/circuits/builtin_xor.circ",
-        .source_name = "builtin_xor.circ",
-        .spec_path = "tests/fixtures/expected-wasm/builtin_xor.txt",
-    },
-    .{
-        .name = "builtin_xnor",
-        .root_path = "tests/fixtures/circuits/builtin_xnor.circ",
-        .source_name = "builtin_xnor.circ",
-        .spec_path = "tests/fixtures/expected-wasm/builtin_xnor.txt",
-    },
-};
-
-test "built-in macros: truth tables (or nand nor xor xnor)" {
-    for (builtin_truth_fixtures) |fx| {
-        try runFixture(fx);
-    }
-}
-
-test "composition: full adder from built-in xor, and, or" {
+// Minimal emit-zig project smoke set. The full behavioral corpus runs on the
+// production path in serializer_fixtures_test.zig; these two only prove the
+// --emit-zig project backend still emits runnable wasm. `full_adder_from_builtins`
+// exercises auto-imported builtins + sub-circuit flattening; `half_adder` is a
+// canonical two-file project.
+test "emit-zig smoke: full adder from built-in xor, and, or" {
     try runFixture(.{
         .name = "full_adder_from_builtins",
         .root_path = "tests/fixtures/circuits/full_adder_from_builtins.circ",
@@ -278,43 +200,7 @@ test "composition: full adder from built-in xor, and, or" {
     });
 }
 
-test "composition: full adder from user half_adder plus xor, and, or macros" {
-    try runFixture(.{
-        .name = "full_adder_ha_or",
-        .root_path = "tests/fixtures/projects/full_adder_ha_or/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/full_adder_ha_or.txt",
-    });
-}
-
-test "Phase 9 edge: single built-in gate only (xor)" {
-    try runFixture(.{
-        .name = "edge_single_builtin",
-        .root_path = "tests/fixtures/circuits/edge_single_builtin.circ",
-        .source_name = "edge_single_builtin.circ",
-        .spec_path = "tests/fixtures/expected-wasm/edge_single_builtin.txt",
-    });
-}
-
-test "Phase 9 edge: deep sub-circuit import chain" {
-    try runFixture(.{
-        .name = "deep_subcircuit_chain",
-        .root_path = "tests/fixtures/projects/deep_subcircuit_chain/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/deep_subcircuit_chain.txt",
-    });
-}
-
-test "Phase 9 stress: deep hierarchy 256 leaf NOTs" {
-    try runFixture(.{
-        .name = "stress_deep_subcircuit",
-        .root_path = "tests/fixtures/projects/stress_deep_subcircuit/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/stress_deep_subcircuit.txt",
-    });
-}
-
-test "canonical: half adder project (sum, carry truth table)" {
+test "emit-zig smoke: half adder project (sum, carry truth table)" {
     try runFixture(.{
         .name = "half_adder",
         .root_path = "tests/fixtures/projects/half_adder/root.circ",
@@ -322,22 +208,3 @@ test "canonical: half adder project (sum, carry truth table)" {
         .spec_path = "tests/fixtures/expected-wasm/projects/half_adder.txt",
     });
 }
-
-test "canonical: full adder project (two half-adders + or)" {
-    try runFixture(.{
-        .name = "full_adder",
-        .root_path = "tests/fixtures/projects/full_adder/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/full_adder.txt",
-    });
-}
-
-test "canonical: 4-bit AND/OR network project" {
-    try runFixture(.{
-        .name = "and_or_network",
-        .root_path = "tests/fixtures/projects/and_or_network/root.circ",
-        .source_name = "root.circ",
-        .spec_path = "tests/fixtures/expected-wasm/projects/and_or_network.txt",
-    });
-}
-


### PR DESCRIPTION
## Summary

The dev-loop `zig build test` had grown to ~221 s (warm), and almost all of it was a single serial tail. Two emit-zig behavioral suites (`tests/emit/behavior_test.zig`, `tests/emit/project_behavior_test.zig`) each spawn a nested `zig build wasm` **per fixture** — ~33 cache-missing WebAssembly compiles per run, one of which alone accounted for ~180 s.

Those suites compile a circuit through the experimental `--emit-zig` backend (standalone Zig source → wasm) and assert its runtime behavior. But that same behavior, over the same 32-fixture corpus and the same expected vectors, is already validated far more cheaply by `tests/e2e/serializer_fixtures_test.zig`, which drives the **production** path: splice topology sections into the prebuilt embedded runtime and run via Node, with no per-fixture compile. The two emit suites were therefore ~100% redundant for *behavioral* coverage; their only unique value is smoke-testing the emit-zig backend itself.

## Change

- Trim the two emit-zig suites to a small backend smoke (2 fixtures each, covering the single-file and multi-file project emit paths).
- Split the build into three steps:
  - `zig build test` — fast dev-loop suite (default); full circuit-behavior coverage retained via `serializer_fixtures_test`.
  - `zig build test-emit` — opt-in emit-zig backend smoke (the nested-build suites).
  - `zig build test-all` — `test` + `test-emit`; the full gate.
- Point `pr-tests.yml` at `test-all` so emit-backend regressions still block merges (the job name is unchanged to preserve the required-check identity).
- Add a build-once guard to `tests/cli/integration_test.zig`, which was invoking `zig build circ-compile` 16 times per run.

## Result

| | before | after |
|---|---|---|
| `zig build test` (dev loop) | ~221 s | ~31 s (7×) |
| `zig build test-all` (CI) | — | ~27 s |

Coverage was verified intact: deliberately breaking the AND-gate evaluator turns the fast `test` red via `serializer_fixtures_test` (plus the truth-table suites).

A prior round of test-speed work (96 s → 25 s, via a persistent wasm workspace) is recorded in `DOCS/archive/plan-test-speed.md`. A natural follow-up — grouping the ~57 per-module test binaries and reusing the installed CLI binary in the integration test instead of rebuilding it — would push the dev loop below ~31 s.
